### PR TITLE
Expose the FT-New-Syndication-User header

### DIFF
--- a/server/middleware/access-control.js
+++ b/server/middleware/access-control.js
@@ -16,6 +16,7 @@ module.exports = (req, res, next) => {
 		res.set('Access-Control-Allow-Origin', requestersOrigin);
 		res.set('Access-Control-Allow-Headers', 'Content-Type');
 		res.set('Access-Control-Allow-Credentials', true);
+		res.set('Access-Control-Expose-Headers', 'FT-New-Syndication-User');
 	}
 
 	if (isCorsRequest && req.method === 'OPTIONS') {


### PR DESCRIPTION
This is needed in order to grab the header’s value from the response
of a client-side CORS fetch