### PR TITLE
Use feature flags

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const accessControl = require('./middleware/access-control');
 const cache = require('./middleware/cache');
+const flags = require('./middleware/flags');
 const decodeSession = require('./middleware/decode-session');
 const checkIfNewSyndicator = require('./middleware/check-if-new-syndicator');
 const app = module.exports = express({
@@ -16,6 +17,7 @@ const middleware = [
 	bodyParser.json(),
 	accessControl,
 	cache,
+	flags,
 	decodeSession,
 	checkIfNewSyndicator
 ];

--- a/server/middleware/check-if-new-syndicator.js
+++ b/server/middleware/check-if-new-syndicator.js
@@ -2,7 +2,8 @@ const logger = require('@financial-times/n-logger').default;
 const newSyndicators = require('../new-syndicators');
 
 module.exports = (req, res, next) => {
-	const isNewSyndicationUser = newSyndicators.includes(res.locals.userUuid);
+	const flags = res.locals.flags;
+	const isNewSyndicationUser = newSyndicators.includes(res.locals.userUuid) || flags.syndicationNewOverride;
 
 	logger.info('in check-if-new-syndicator middleware', { isNewSyndicationUser });
 

--- a/server/middleware/flags.js
+++ b/server/middleware/flags.js
@@ -1,0 +1,7 @@
+module.exports = (req, res, next) => {
+	if (res.locals.flags && res.locals.flags.syndicationNew) {
+		next();
+	} else {
+		res.sendStatus(404);
+	}
+};


### PR DESCRIPTION
- Don’t serve requests if the `syndicationNew` flag is off
- Force the api to treat user as opted into the new system, via the
  `syndicationNewOverride` flag