### PR TITLE
correct downloaded count

### DIFF
--- a/server/lib/resolve/canDownload.js
+++ b/server/lib/resolve/canDownload.js
@@ -18,7 +18,8 @@ module.exports = exports = (val, prop, item, existing, contract) => {
 		}
 
 		if (asset.download_limit > -1) {
-			if (asset.download_limit - asset.current_downloads.total > 0) {
+			const downloaded_total = asset.current_downloads.total + (asset.legacy_download_count || 0)
+			if (asset.download_limit - downloaded_total > 0) {
 				return 1;
 			}
 			else {

--- a/test/server/lib/resolve/canDownload.spec.js
+++ b/test/server/lib/resolve/canDownload.spec.js
@@ -34,4 +34,8 @@ describe(MODULE_ID, function () {
 	it('returns -1', function() {
 		expect(underTest(undefined, 'canDownload', { type: 'http://www.ft.com/ontology/content/Video' }, null, { itemsMap: { video: { download_limit: 10, current_downloads: { total: 10 } } } })).to.equal(-1);
 	});
+
+	it('returns -1 with legacy_download_count taken into account', function() {
+		expect(underTest(undefined, 'canDownload', { type: 'http://www.ft.com/ontology/content/Video' }, null, { itemsMap: { video: { legacy_download_count: 9, download_limit: 10, current_downloads: { total: 1 } } } })).to.equal(-1);
+	});
 });


### PR DESCRIPTION
The assets' legacy download count wasn't being taken into account when calculated whether a contract had run out of content to download. This meant that some users were incorrectly able to download more content that their contract allowed, despite running out.

 🐿 v2.5.16