### PR TITLE
correct MSG_2000 logic

### DIFF
--- a/schema/message-v1.json
+++ b/schema/message-v1.json
@@ -5,6 +5,9 @@
     "_id": {
       "type": "string"
     },
+    "canDownload": {
+      "type": "number"
+    },
     "content_id": {
       "format": "uri",
       "type": "string"

--- a/server/lib/resolve/messageCode.js
+++ b/server/lib/resolve/messageCode.js
@@ -41,7 +41,7 @@ const MESSAGE_CODE_RULES = exports.MESSAGE_CODE_RULES = {
 	MSG_4050: (item) =>
 		(item.notAvailable === true),
 	MSG_2000: (item, contract) =>
-		(item.canBeSyndicated === 'yes' && !MESSAGE_CODE_RULES.MSG_2100(item, contract)),
+		(item.canBeSyndicated === 'yes' && !MESSAGE_CODE_RULES.MSG_2100(item, contract) && item.canDownload === 1),
 	MSG_2100: (item, contract) =>
 		(item.downloaded === true && !MESSAGE_CODE_RULES.MSG_2300(item, contract) && !MESSAGE_CODE_RULES.MSG_2340(item, contract)),
 	MSG_2200: (item) =>

--- a/test/server/lib/resolve/messsageCode.spec.js
+++ b/test/server/lib/resolve/messsageCode.spec.js
@@ -27,7 +27,7 @@ describe(MODULE_ID, function () {
 	});
 
 	const messageItemMap = {
-		MSG_2000: { canBeSyndicated: 'yes', downloaded: false },
+		MSG_2000: { canBeSyndicated: 'yes', downloaded: false, canDownload: 1 },
 		MSG_2100: { canBeSyndicated: 'yes', downloaded: true },
 		MSG_2200: { canBeSyndicated: 'verify', canDownload: -1 },
 //		MSG_2300: { canBeSyndicated: 'withContributorPayment' },

--- a/test/worker/sync/db-persist/spoor-publish.spec.js
+++ b/test/worker/sync/db-persist/spoor-publish.spec.js
@@ -55,6 +55,7 @@ describe(MODULE_ID, function () {
 	it('publishes a message queue event to spoor', async function () {
 		const event = (new MessageQueueEvent({
 			event: {
+				canDownload: 1,
 				content_id: 'http://www.ft.com/thing/abc',
 				contract_id: 'syndication',
 				download_format: 'docx',


### PR DESCRIPTION
We have been sending a MSG_2000 code for content even if it wasn't downloadable on the contract. This adds a check to ensure the user can download. 

## Before
<img width="1234" alt="screenshot 2017-12-01 17 59 31" src="https://user-images.githubusercontent.com/11544418/33496266-77ff9d50-d6c1-11e7-8f2b-dfa1f5655f2b.png">

## After
<img width="1201" alt="screenshot 2017-12-01 17 59 56" src="https://user-images.githubusercontent.com/11544418/33496272-7e7ca736-d6c1-11e7-99b3-ee0b8e547af3.png">


 🐿 v2.5.16