### PR TITLE
Bump api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "main": "server/init.js",
   "dependencies": {


### PR DESCRIPTION
This is predominantly for upgrading dependant services eg, https://github.com/Financial-Times/next-syndication-dl/blob/master/package.json#L10, allowing them to [upgrade deps](https://github.com/Financial-Times/next-syndication-api/pull/96).

See https://trello.com/c/rLcIbPr4/425-ensure-that-no-apps-are-still-reading-from-the-old-graphite-server