### PR TITLE
Bump n-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@financial-times/n-es-client": "^1.3.1",
     "@financial-times/n-express": "^19.19.4",
     "@financial-times/n-handlebars": "^1.17.8",
-    "@financial-times/n-logger": "^5.5.3",
+    "@financial-times/n-logger": "^6.0.2",
     "@financial-times/session-decoder-js": "^1.0.1",
     "ajv": "^5.1.5",
     "archiver": "^1.3.0",


### PR DESCRIPTION
Use new n-logger to fix circularly reference json crashing the app.

See https://trello.com/c/btr1Wnlw/417-business-customer-is-unable-to-access-their-syndication-service