### PR TITLE
Pin node to v8.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node8: &container_config_node8
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:8.13-browsers
 
   container_config_lambda_node8: &container_config_lambda_node8
     working_directory: ~/project/build

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     ]
   },
   "engines": {
-    "node": "^8.9.3"
+    "node": "8.13.0"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
Changes:

- `package.json` field `engines.node` - updated, previously: `^8.9.3`
- `.nvmrc` - no change, does not exist
- `.circleci/config.yml` Docker image for `container_config_node8` - updated, previously: `circleci/node:8-browsers`

Related issues:

- https://github.com/Financial-Times/next-transformations/issues/12
- https://github.com/Financial-Times/next-bugs/issues/222
