### PR TITLE
Add Snyk to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps
+      - run: snyk monitor --org=customer-products
       - run:
           name: Deploy to production
           command: make deploy

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "nodemailer": "^4.1.0",
     "s3-upload-stream": "^1.0.7",
     "shelljs": "^0.7.8",
+    "snyk": "^1.165.2",
     "xmldom": "^0.1.27"
   },
   "devDependencies": {
@@ -108,7 +109,8 @@
     "prepush": "make verify -j3",
     "commit": "commit-wizard",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "heroku-postbuild": "make heroku-postbuild"
+    "heroku-postbuild": "make heroku-postbuild",
+    "prepare": "node_modules/.bin/snyk protect"
   },
   "config": {}
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our app repos for security reasons.  It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365