### PR TITLE
Add Snyk to Project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/next-syndication-api
       - run:
           name: Deploy to production
           command: make deploy

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@financial-times/n-gage": "^3.0.0-beta.8",
     "@financial-times/n-heroku-tools": "^8.0.0-beta.4",
+    "@financial-times/n-test": "^1.13.2",
     "chai": "^4.0.2",
     "coveralls": "^2.13.1",
     "decompress": "^4.2.0",
@@ -54,7 +55,7 @@
     "proxyquire": "^1.7.4",
     "sinon": "^6.0.0",
     "sinon-chai": "^3.2.0",
-    "@financial-times/n-test": "^1.13.2"
+    "snyk": "^1.167.0"
   },
   "nyc": {
     "exclude": [
@@ -108,7 +109,8 @@
     "prepush": "make verify -j3",
     "commit": "commit-wizard",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "heroku-postbuild": "make heroku-postbuild"
+    "heroku-postbuild": "make heroku-postbuild",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "config": {}
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our app repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365