### PR TITLE
add graphiteName field to n-express options

### DIFF
--- a/server/app-dl.js
+++ b/server/app-dl.js
@@ -25,7 +25,7 @@ const routeMaintenanceMode = require('./middleware/route-maintenance-mode');
 
 const app = module.exports = express({
 	systemCode: 'next-syndication-dl',
-	graphiteName: 'syndication-api',
+	graphiteName: 'syndication-dl',
 	withBackendAuthentication: false,
 	withFlags: true
 });

--- a/server/app-dl.js
+++ b/server/app-dl.js
@@ -25,6 +25,7 @@ const routeMaintenanceMode = require('./middleware/route-maintenance-mode');
 
 const app = module.exports = express({
 	systemCode: 'next-syndication-dl',
+	graphiteName: 'syndication-api',
 	withBackendAuthentication: false,
 	withFlags: true
 });

--- a/server/app.js
+++ b/server/app.js
@@ -25,6 +25,7 @@ const routeMaintenanceMode = require('./middleware/route-maintenance-mode');
 
 const app = module.exports = express({
 	systemCode: 'next-syndication-api',
+	graphiteName: 'syndication-api',
 	withFlags: true,
 	healthChecks: [
 		require('../health/db-backups'),


### PR DESCRIPTION
See financial-times/n-express#563 for details.

This change requires n-express@19.22 to work but can be safely merged without it