### PR TITLE
Increasing the Threshold for 401 error spike alerts

### DIFF
--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -3,10 +3,10 @@ const nHealth = require('n-health');
 module.exports = nHealth.runCheck({
 	type: 'graphiteThreshold',
 	metric: 'divideSeries(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.401.count),sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count))',
-	threshold: 0.02,
+	threshold: 0.10,
 	name: '401 rate for articles is acceptable',
 	severity: 1,
-	businessImpact: 'Error rate for the syndication-api is higher than the acceptable threshold of 2%.',
-	technicalSummary: 'The proportion of 401 (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of 0.02',
+	businessImpact: 'Error rate for the syndication-api is higher than the acceptable threshold of 10%.',
+	technicalSummary: 'The proportion of 401 (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of 0.10',
 	panicGuide: 'Check the heroku logs for the app for any error messages. Possible causes could be incorrect data from Salesforce or Membership’s ALS'
 })


### PR DESCRIPTION
The 401 error spike alert goes off quite often - after looking into it, it seems that as there is low traffic to the service, even a single visit to https://www.ft.com/republishing/contract by a non-syndicated user will generate an alert.
I'm not sure what the level should be; however updating the proportion to 10% of all requests might be an improvement.

<img width="617" alt="Screenshot 2019-10-28 at 11 34 23" src="https://user-images.githubusercontent.com/1217931/67675623-820faa80-f977-11e9-9373-8581b68afef5.png">
