### PR TITLE
Removes ft-next-syndication-api-https

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -101,8 +101,6 @@ If this is a problem for all Syndication users it could be:
 ## Healthchecks
 
 - ft-next-syndication-api.herokuapp.com-https
-- ft-next-syndication-api-https
-
 
 ## Failover Architecture Type
 
@@ -161,5 +159,3 @@ See the Customer Products [key management and troubleshooting wiki page](https:/
 - salesforce
 - up-ica
 - next-esinterface
-
-


### PR DESCRIPTION
There were two health check links under the HealthCheck header both of these pages point to the same health check so I have decided to remove ft-next-syndication-api-https

This health check page will then be deleted from biz-ops