### PR TITLE
adds a samplePeriod parameter to the 401 reponses healthcheck 🐿 v2.12.5

### DIFF
--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -4,9 +4,10 @@ module.exports = nHealth.runCheck({
 	type: 'graphiteThreshold',
 	metric: 'divideSeries(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.401.count),sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count))',
 	threshold: 0.10,
+	samplePeriod: '15min',
 	name: '401 rate for articles is acceptable',
 	severity: 1,
-	businessImpact: 'Error rate for the syndication-api is higher than the acceptable threshold of 10%.',
+	businessImpact: 'Error rate for the syndication-api has exceeded a threshold of 10% over the last 15 minutes.',
 	technicalSummary: 'The proportion of 401 (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of 0.10',
 	panicGuide: 'Check the heroku logs for the app for any error messages. Possible causes could be incorrect data from Salesforce or Membership’s ALS'
 })


### PR DESCRIPTION
Updates the 401 responses healthcheck for the next-syndiation-api to include a `samplePeriod` parameter.

The threshold for this alert is currently set to 10%, which ordinarily would be very high, but we commonly receive between 1 and 4 requests per minute to the syndication-api, meaning a single 401 can easily trigger this alert.

Adding a `samplePeriod` parameter to the healthcheck should mitigate the effects of single 401 responses and trigger an alert only when there is a genuine problem with the app. This will help ops-cops to identify and respond to genuine errors more efficiently.

[ops-cops ticket](https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952)