### PR TITLE
NOPSCOSP-224 Increase the sample period to 20 minutes

### DIFF
--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -4,7 +4,7 @@ module.exports = nHealth.runCheck({
 	type: 'graphiteThreshold',
 	metric: 'divideSeries(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.401.count),sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count))',
 	threshold: 0.10,
-	samplePeriod: '15min',
+	samplePeriod: '20min',
 	name: '401 rate for articles is acceptable',
 	severity: 1,
 	businessImpact: 'Error rate for the syndication-api has exceeded a threshold of 10% over the last 15 minutes.',

--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -7,7 +7,7 @@ module.exports = nHealth.runCheck({
 	samplePeriod: '20min',
 	name: '401 rate for articles is acceptable',
 	severity: 1,
-	businessImpact: 'Error rate for the syndication-api has exceeded a threshold of 10% over the last 15 minutes.',
-	technicalSummary: 'The proportion of 401 (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of 0.10',
+	businessImpact: 'Error rate for the syndication-api has exceeded a threshold of 10% over the last 20 minutes.',
+	technicalSummary: 'The proportion of 401 (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of 0.10 over the last 20 minutes',
 	panicGuide: 'Check the heroku logs for the app for any error messages. Possible causes could be incorrect data from Salesforce or Membership’s ALS'
 })


### PR DESCRIPTION
## Meta
See similar PR #188 
Jira [NOPSCOPS-224](https://financialtimes.atlassian.net/browse/NOPSCOPS-224)

## Description
From a look at the data, the alarm **"401 rate for articles is acceptable, severity 1 issue"** was cause by only a couple of 401 response during the 15 minutes sample, which caused the 10% threshold to be surpassed due to low traffic.

![syndication-api 2020-03-17 14:47 - Screenshot from 2020-03-17 17-12-43](https://user-images.githubusercontent.com/21342215/76885066-95fc7000-6876-11ea-8430-72b74dd190c9.png)

Similarly to what was done in #188, this PR increases the `samplePeriod` from 15 to 20 minutes to reduce the impact of these 401s when the traffic is low.