### PR TITLE
Fix healthchecks typo 🐿 v2.12.6

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,7 +29,7 @@ const app = module.exports = express({
 	withFlags: true,
 	healthChecks: [
 		require('../health/db-backups'),
-		require('../health/db-backups'),
+		require('../health/db-sync-state'),
 		require('../health/sqs'),
 		require('../health/error-spikes'),
 	].concat(


### PR DESCRIPTION
 - Require statement was incorrectly imported twice.