### PR TITLE
Increase SQS healthcheck threshold 🐿 v2.12.6

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -133,7 +133,7 @@
     - pull-quote
 
   HEALTH_CHECK_HISTORY:
-    bloated_threshold: 50
+    bloated_threshold: 70
     directory: ./health/history
     file_date_format: YYYY-MM-DD[T]HH-mm-ss[.json]
     max_items: 10


### PR DESCRIPTION
- Bump up the threshold for how many messages can be in the queue at any one time.