### PR TITLE
Change 401 healthcheck metric

### DIFF
--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -1,6 +1,6 @@
 const nHealth = require('n-health');
 const statusCode = 401;
-const threshold = 0.04;
+const threshold = 2;
 const samplePeriod = 60; // minutes
 
 module.exports = nHealth.runCheck({

--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -1,11 +1,11 @@
 const nHealth = require('n-health');
 const statusCode = 401;
-const threshold = 0.33;
+const threshold = 0.04;
 const samplePeriod = 60; // minutes
 
 module.exports = nHealth.runCheck({
 	type: 'graphiteThreshold',
-	metric: `divideSeries(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.${statusCode}.count),sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count))`,
+	metric: `asPercent(summarize(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.${statusCode}.count), "${samplePeriod}min", "sum", true), summarize(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count), "${samplePeriod}min", "sum", true))`,
 	threshold,
 	samplePeriod: `${samplePeriod}min`,
 	name: `${statusCode} rate for articles is acceptable`,


### PR DESCRIPTION
The `sumSeries` function in Graphite only returns ["the sum at **each** datapoint"](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.sumSeries), rather than summing all data points over a certain sample period. 

So if one 401 and one 200 are returned at the same time (as happened this afternoon in the graph below), this healthcheck will fail as crosses the threshold with a 50% failure rate.

<img width="648" alt="image" src="https://user-images.githubusercontent.com/7748470/78382781-471d3d00-75cf-11ea-8820-81bde73a3948.png">

To fix this we instead need to use the `summarize` function to sum all data points over a certain time.
