### PR TITLE
Added link to Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 The API behind the new FT.com/republishing tool.
 
+## What is Syndication and how does it work
+
+For an explanation, including a Slides deck which explains the infrastructure, please see [the Wiki page](https://github.com/Financial-Times/next/wiki/Syndication)
+
 ## Installation
 
 ```shell


### PR DESCRIPTION
Wiki has a bit more info about Syndication and isn't the most obvious place to look, so people on OpsCops might struggle to find the info they need.