### PR TITLE
Remove Handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-handlebars": "2.0.0",
     "@financial-times/n-internal-tool": "3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",
@@ -16,6 +15,7 @@
     "body-parser": "^1.17.1",
     "config": "^1.26.1",
     "cookie-parser": "^1.4.3",
+    "handlebars": "^4.7.6",
     "hat": "^0.0.3",
     "js-yaml": "^3.8.4",
     "jsonpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",

--- a/server/lib/decorate-article.js
+++ b/server/lib/decorate-article.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { handlebars } = require('@financial-times/n-handlebars');
+const handlebars  = require('./handlebars');
 const moment = require('moment');
 const { DOMParser } = require('xmldom');
 

--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -5,11 +5,11 @@ const Handlebars = require('handlebars');
 module.exports = function () {
 	const helpers = {
 		ifEquals: function (a, b, options) {
-            if (a === b) {
-                return options.fn(this);
-            }
-            return options.inverse(this);
-        }
+			if (a === b) {
+				return options.fn(this);
+			}
+			return options.inverse(this);
+		}
 	};
 
 	const handlebars = Handlebars;

--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const Handlebars = require('handlebars');
+
+module.exports = function () {
+	const helpers = {
+		ifEquals: function (a, b, options) {
+            if (a === b) {
+                return options.fn(this);
+            }
+            return options.inverse(this);
+        }
+	};
+
+	const handlebars = Handlebars;
+	handlebars.registerHelper(helpers);
+	return handlebars;
+};

--- a/test/server/lib/handlebars.spec.js
+++ b/test/server/lib/handlebars.spec.js
@@ -4,13 +4,13 @@ const { expect } = require('chai');
 const Handlebars = require('../../../server/lib/handlebars')();
 
 describe('Handlebars with extended helper', function () {
-    it('Should register an ifEquals helper', function () {
-        expect(Handlebars.helpers).to.haveOwnProperty('ifEquals');
-    });
+	it('Should register an ifEquals helper', function () {
+		expect(Handlebars.helpers).to.haveOwnProperty('ifEquals');
+	});
 
-    it('should render a template using ifEquals helper', function () {
-        const template = Handlebars.compile('{{#ifEquals thing1 "thing1"}}first{{else}}not first{{/ifEquals}} {{#ifEquals thing1 "thing2"}}second{{else}}not second{{/ifEquals}}');
-        const rendered = template({thing1: 'thing1', thing2: 'thing2'});
-        expect(rendered).to.eql('first not second')
+	it('should render a template using ifEquals helper', function () {
+		const template = Handlebars.compile('{{#ifEquals thing1 "thing1"}}first{{else}}not first{{/ifEquals}} {{#ifEquals thing1 "thing2"}}second{{else}}not second{{/ifEquals}}');
+		const rendered = template({thing1: 'thing1', thing2: 'thing2'});
+		expect(rendered).to.eql('first not second')
 	});
 });

--- a/test/server/lib/handlebars.spec.js
+++ b/test/server/lib/handlebars.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { expect } = require('chai');
+const Handlebars = require('../../../server/lib/handlebars')();
+
+describe('Handlebars with extended helper', function () {
+    it('Should register an ifEquals helper', function () {
+        expect(Handlebars.helpers).to.haveOwnProperty('ifEquals');
+    });
+
+    it('should render a template using ifEquals helper', function () {
+        const template = Handlebars.compile('{{#ifEquals thing1 "thing1"}}first{{else}}not first{{/ifEquals}} {{#ifEquals thing1 "thing2"}}second{{else}}not second{{/ifEquals}}');
+        const rendered = template({thing1: 'thing1', thing2: 'thing2'});
+        expect(rendered).to.eql('first not second')
+	});
+});

--- a/test/server/lib/handlebars.spec.js
+++ b/test/server/lib/handlebars.spec.js
@@ -9,8 +9,8 @@ describe('Handlebars with extended helper', function () {
 	});
 
 	it('should render a template using ifEquals helper', function () {
-		const template = Handlebars.compile('{{#ifEquals thing1 "thing1"}}first{{else}}not first{{/ifEquals}} {{#ifEquals thing1 "thing2"}}second{{else}}not second{{/ifEquals}}');
-		const rendered = template({thing1: 'thing1', thing2: 'thing2'});
-		expect(rendered).to.eql('first not second')
+		const template = Handlebars.compile('{{#ifEquals propA 1}}propA: render this;{{else}}propA: do not render this{{/ifEquals}}{{#ifEquals propB 5}} propB: do not render this{{else}} propB: render this{{/ifEquals}}');
+		const rendered = template({propA: 1, propB: 2});
+		expect(rendered).to.eql('propA: render this; propB: render this')
 	});
 });

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { handlebars } = require('@financial-times/n-handlebars');
+const handlebars = require('../../../server/lib/handlebars');
 const log = require('../../../server/lib/logger');
 
 //const moment = require('moment');


### PR DESCRIPTION
Since this project was only using the exported `handlebars` method from `n-handlebars` which was essentially just the regular `handlebars` module you can fin in NPM, I removed it and replaced it for regular the `handlebars` module.

The only extended helper being used on the project is #ifEquals so I added that helper as well to the regular `handlebars` module.

I also added unit tests to test the newly added handlebars code.