### PR TITLE
ACC-530 chore: update n-internal-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-internal-tool": "6.0.0",
+    "@financial-times/n-internal-tool": "6.0.1",
     "@financial-times/s3o-middleware": "^3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-internal-tool": "5.0.0",
+    "@financial-times/n-internal-tool": "6.0.0",
     "@financial-times/s3o-middleware": "^3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-internal-tool": "3.0.0",
+    "@financial-times/n-internal-tool": "4.0.0",
+    "@financial-times/s3o-middleware": "^3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",
     "ajv": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-internal-tool": "4.0.0",
+    "@financial-times/n-internal-tool": "5.0.0",
     "@financial-times/s3o-middleware": "^3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",
     "@financial-times/n-express": "19.22.12",
-    "@financial-times/n-internal-tool": "6.0.1",
+    "@financial-times/n-internal-tool": "7.0.0",
     "@financial-times/s3o-middleware": "^3.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.1",

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@
 process.env.TZ = 'UTC';
 
 const express = require('@financial-times/n-internal-tool');
+const authS3O = require('@financial-times/s3o-middleware');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
@@ -35,7 +36,6 @@ const app = module.exports = express({
 	].concat(
 		require('../health/middlewares')
 	),
-	s3o: false
 });
 
 const middleware = [
@@ -100,7 +100,7 @@ app.get('/syndication/reload', middleware, require('./controllers/reload'));
 
 // Page for handling erasure requests
 const erasureMiddleware = [
-	express.authS3O,
+	authS3O,
 	cookieParser(),
 	bodyParser.urlencoded({ extended: true }),
 	flagMaintenanceMode,


### PR DESCRIPTION
This PR updates [n-internal-tools](https://github.com/Financial-Times/n-internal-tool) from `3.0.0` to `4.0.0`

**Version 4.0.0** removes s30 middleware from n-internal-tool  [#35](https://github.com/Financial-Times/n-internal-tool/pull/35)
**Version 5.0.0** Adds .o-grid-container--snappy class  [#36](https://github.com/Financial-Times/n-internal-tool/pull/39)
**Version 6.0.0**   Removes n-handlebars and uses express-handlebars
**Version 7.0.0**   Stable release