### PR TITLE
Bump `next-syndication-api` version to 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",


### PR DESCRIPTION
This PR bumps `next-syndication-api` version to 0.32.0 to match release tag.