### PR TITLE
ACC-546 enhanced enrich step to create "rich article" type 

### DIFF
--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -25,6 +25,10 @@ module.exports = exports = function article(content, format) {
 		content.content_type = CONTENT_TYPE_ALIAS[content.type] || content.type;
 	}
 
+	if (content.contentStats && content.contentStats.graphics && content.contentStats.graphics > 0){
+		content.content_type = 'rich article'
+	}
+
 	content.extension = DOWNLOAD_ARTICLE_FORMATS[format] || 'docx';
 
 	if (content.body && !content.bodyHTML) {


### PR DESCRIPTION
### Why is the change made here?

We want the content type to be correct at the point on saving. This is happening in `server/controllers/save-by-content-id.js`.
That controller gets their `content` by `await getContentById()` (line 34)

In `server/lib/get-content-by-id.js` the content is fetched from Elastic Search (line 33 `await esClient.get()`).
In the same file, the content fetched in enriched (line 48 `enrich()`)

The enrich main file `server/lib/enrich/index.js` enriches the content by passing it into the relevant enrich helper. 

I added the rich article enricher after the base enricher, so that as a fail safe there'll always be a type of article.