### PR TITLE
ACC-622 Enhance response to include info about Graphic syndication

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,225 +1,156 @@
 module.exports = {
 	files: {
 		allow: [
-			'pandoc-dpkg\/.*',
-			'server\/views\/partial\/.*?\.hbs',
-			'test\/fixtures\/.*'
+			'pandoc-dpkg/usr/bin/pandoc',
+			'pandoc-dpkg/usr/bin/pandoc-citeproc',
+			'pandoc-dpkg/usr/share/doc/pandoc/copyright',
+			'pandoc-dpkg/usr/share/man/man1/pandoc-citeproc.1.gz',
+			'pandoc-dpkg/usr/share/man/man1/pandoc.1.gz',
+			'test/fixtures/article.docx',
+			'test/fixtures/article.plain',
+			'test/fixtures/pandoc_stub',
+			'test/fixtures/podcast.m4a',
+			'test/fixtures/video-small.mp4'
 		],
 		allowOverrides: []
 	},
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'john.q@average.com',
-			'foo@bar.com',
-			'http(?:s?):\/\/.*',
-			'\/content\/.*',
-			// _ids
-			'167e9de0f286d5d771a89b864c053ea8',
-			'9807a4b6dcb3ce1188593759dd6818cd',
-			'f55885427fa5f8c3e2b90204a6e6b0c7',
-			'4eff4aba81093b44d2a71c36fc8e9898',
-			'c71c4e6cf5183996a34235bf50bc0e1d',
-			'1643097dede85a81e5e94cd6168a0a06',
-			'd7cf17839495d7176ae7b986e6ce3eff',
-			'108ff39fefbaff6a7f889287e1e7f0ff',
-			'095ffdbf50ee4041ee18ed9077216844',
-			'6feabf0d4eed16682bfbd6d3560a45ee',
-			'8d1beddb5cc7ed98a61fc28934871b35',
-			'ee0981e4bebd818374a6c1416029656f',
-			'9d5272af0a36ca429249c25899a64f88',
-			'45bd7ff4e01052bb77a839766e1e69d9',
-			// user UUIDs
-			'f74e5115-922b-409f-a82f-707a0c85e155',
-			'8ef593a8-eef6-448c-8560-9ca8cdca80a5',
-			'8ef593a8-eef6-448c-8560-9ca8cdca80a6',
-			'b2697f93-52d3-4d42-8409-bdf91b09e894',
-			// licence UUIDs
-			'a0b1c2d3-e4f5-g6h7-i9j0-k1l2m3n4o5p6',
-			'z0y8x7w6-v5u4-t3s2-r1q0-p9o8n7m6l5k4',
-			'c3e9b81a-c477-11e7-b2bb-322b2cb39656',
-			'a22ff86e-ba37-11e7-9bfb-4a9c83ffa852',
-			'40a86de6-b5dd-11e7-a398-73d59db9e399',
-			'081b2240-ae7e-11e7-aab9-abaa44b1e130',
-			'286ad07a-c415-11e7-b2bb-322b2cb39656',
-			'315daef2-b1c1-11e7-aa26-bb002965bce8',
-			'c3391af1-0d46-4ddc-a922-df7c49cf1552',
-			'f0e793d6-90d6-4581-9743-c905940602f5',
-			'eb5982b4-b3ff-11e7-a398-73d59db9e399',
-			// content UUIDs
-			'52be3c0c-7831-11e7-a3e8-60495fe6ca71',
-			'd4efba32-d2ca-11e6-b06b-680c49b4b4c0',
-			'b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7',
-			'b3ec55b0-7dd4-11e7-9108-edda0bcbc928',
-			'02c03200-86dc-11e7-bf50-e1c239b45787',
-			'491cf75e-51d2-11e7-a1f2-db19572361bb',
-			'02c03200-86dc-11e7-bf50-e1c239b45787',
-			'9fdf35a4-7610-11e7-a3e8-60495fe6ca71',
-			'6326f528-75db-11e7-a3e8-60495fe6ca71',
-			'b59dff10-3f7e-11e7-9d56-25f963e998b2',
-			'c7923fba-1d31-39fd-82f0-ba1822ef20d2',
-			'80d634ea-fa2b-46b5-886f-1418c6445182',
-			'd7bf1822-ec58-4a8e-a669-5cbcc0d6a1b2',
-			'dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54',
-			'd0842750-9903-4bf9-2ee7-f3d98afabc1e',
-			'16a642f4-3f84-11e7-1cd0-1ef14f87a411',
-			'faf86fbc-0009-11df-8626-00144feabdc0',
-			'34b704a0-54d7-11e7-9fed-c19e2700005f',
-			'b4fac748-a2b1-4b7d-8e1f-03ba743ff717',
-			'00004ffc-004e-50ad-0337-456ae1b1861c',
-			'6ce05235-c102-48b9-a886-95dbd7f40419',
-			'de2390cd-46a1-4c58-2914-f5f50e13f766',
-			'cada14c4-d366-11e6-b06b-680c49b4b4c0',
-			'302d79cc-e6e3-11e5-a09b-1f8b0d268c39',
-			'2ece7d55-f2c5-30d5-8119-df841dfb64ea',
-			'048f418c-2487-11e7-a34a-538b4cb30025',
-			'16e86360-4096-11e7-1cd0-1ef14f87a411',
-			'2e055d50-2453-11e7-18f7-426d3ab9a15f',
-			'6b24d1b8-1ac9-11e7-bcac-6d03d067f81f',
-			'2778b97a-5bc9-11e7-9bc8-8055f264aa8b',
-			'dbe4928a-5bec-11e7-b553-e2df1b0c3220',
-			'fakenews-fa2b-46b5-886f-1418c6445182',
-			'fakenews-3f7e-11e7-9d56-25f963e998b2',
-			'fakenews-1d31-39fd-82f0-ba1822ef20d2',
-			'fakenews-ec58-4a8e-a669-5cbcc0d6a1b2',
-
-			'260b270a-723d-11e7-93ff-99f383b09ff9',
-			'32d8f4b0-5d58-434d-b578-337486e9f714',
-			'52be3c0c-7831-11e7-a3e8-60495fe6ca71',
-			'967fb202-c532-11e6-8f29-9445cac8966f',
-			'd73e2fe9-8677-4b1a-b9a9-7d72805e1a93',
-			'fa6de70c-e9b8-11e6-893c-082c54a7f539',
-			'f743871c-3499-4844-9d2b-685fcd94f9c8',
-			'f743871c-3499-4844-9d2b-685fcd94f9c7',
-			'b83df96a-67c7-3618-9fc1-db357bf775eb',
-			'8a9d1cd8-f4da-38d6-a4eb-195d6a41d902',
-			'8a086a54-ea48-3a52-bd3c-5821430c2132',
-			'5ea997c8-1de2-3add-8e63-8639fc2459c9',
-			'0f22b715-20dc-498c-a548-907bbf337ee4',
-			'e3e9ac6a-5f2d-11e7-8814-0ac7eb84e5f1',
-			'9f4698fc-5fe6-11e7-91a7-502f7ee26895',
-			'193c3dd0-5f40-11e7-8814-0ac7eb84e5f1',
-			'558b82dc-5f36-11e7-91a7-502f7ee26895',
-			'49c4c5fc-5fc8-11e7-91a7-502f7ee26895',
-			'542f5aa6-6000-11e7-91a7-502f7ee26895',
-			'a37c2aee-565f-11e7-80b6-9bfa4c1f83d2',
-			'249a422c-5f49-11e7-8814-0ac7eb84e5f1',
-			'2ddf5280-5ec9-11e7-91a7-502f7ee26895',
-			'ed5af0b0-5fcd-11e7-8814-0ac7eb84e5f1',
-			'0c3427b2-5ce1-11e7-9bc8-8055f264aa8b',
-			'4be8ccb6-5fbe-11e7-91a7-502f7ee26895',
-			'd4333820-5fcf-11e7-8814-0ac7eb84e5f1',
-			'18e5dc98-5f2b-11e7-8814-0ac7eb84e5f1',
-			'84f51c84-5fe2-11e7-91a7-502f7ee26895',
-			'08fd7550-5d8e-11e7-9bc8-8055f264aa8b',
-			'1bc10566-5dbc-11e7-b553-e2df1b0c3220',
-			'e48746f0-5d9d-11e7-9bc8-8055f264aa8b',
-			'9df85594-5f3c-11e7-91a7-502f7ee26895',
-			'e55a7d50-5fe0-11e7-91a7-502f7ee26895',
-			'182f9e5c-5fbb-11e7-91a7-502f7ee26895',
-			'e3e3b508-5fcd-11e7-8814-0ac7eb84e5f1',
-			'7db088aa-5fd3-11e7-91a7-502f7ee26895',
-			'c4de73e2-17a1-11e7-9c35-0dd2cb31823a',
-			'0c3427b2-5ce1-11e7-9bc8-8055f264aa8b',
-			'6e873378-5d68-11e7-b553-e2df1b0c3220',
-			'558b82dc-5f36-11e7-91a7-502f7ee26895',
-			'2bc88a88-5d76-11e7-9bc8-8055f264aa8b',
-			'3d5425ac-5dbf-11e7-b553-e2df1b0c3220',
-			'5cf22564-5f2a-11e7-8814-0ac7eb84e5f1',
-			'11e1f8f8-5ce4-11e7-b553-e2df1b0c3220',
-			'0f65f08a-5bdf-11e7-b553-e2df1b0c3220',
-			'b435ac9c-5f34-11e7-91a7-502f7ee26895',
-			'fcd156d2-559c-11e7-9fed-c19e2700005f',
-			'5e3b5c10-5fd4-11e7-91a7-502f7ee26895',
-			'6e873378-5d68-11e7-b553-e2df1b0c3220',
-			'97582468-5fc7-11e7-8814-0ac7eb84e5f1',
-			'2bc88a88-5d76-11e7-9bc8-8055f264aa8b',
-			'c744f370-5c22-11e7-b553-e2df1b0c3220',
-			'20fc83ce-5750-11e7-80b6-9bfa4c1f83d2',
-			'7f59d55c-550c-11e7-80b6-9bfa4c1f83d2',
-			'adb62f1a-5fd2-11e7-91a7-502f7ee26895',
-			'236010a6-5d84-11e7-9bc8-8055f264aa8b',
-			'13595a36-5f8d-11e7-8814-0ac7eb84e5f1',
-			'56408542-5fef-11e7-8814-0ac7eb84e5f1',
-			'41a9eedc-5f97-11e7-91a7-502f7ee26895',
-			'5d3cefe0-6001-11e7-8814-0ac7eb84e5f1',
-			'9ca89fd6-5fbf-11e7-8814-0ac7eb84e5f1',
-			'c4de73e2-17a1-11e7-9c35-0dd2cb31823a',
-			'c9762724-5d88-11e7-b553-e2df1b0c3220',
-			'542f5aa6-6000-11e7-91a7-502f7ee26895',
-			'3d5425ac-5dbf-11e7-b553-e2df1b0c3220',
-			'7f59d55c-550c-11e7-80b6-9bfa4c1f83d2',
-			'353e6420-5d85-11e7-b553-e2df1b0c3220',
-			'2de5b336-4a89-11e7-a3f4-c742b9791d43',
-			'2cfaa304-5fe8-11e7-8814-0ac7eb84e5f1',
-			'141587fa-5b29-11e7-9bc8-8055f264aa8b',
-			'786bfddc-5daf-11e7-b553-e2df1b0c3220',
-			'87771406-5b34-11e7-b553-e2df1b0c3220',
-			'6cd35cc3-b836-4f6c-bdf4-2f5c08fc4afb',
-			'66bff390-62b5-48a9-90ce-edb4f5d460ef',
-			'a62daaf1-cde0-4c3c-950d-ee4253ddf510',
-			'019bdde8-cbc5-4206-a12e-9c091c39f33a',
-			'112f5471-03ac-4454-8aa7-3558a7e3e452',
-			'14f4fef7-eef1-4cc5-afbb-b157f20122cb',
-			'337aae4a-550a-45da-9a3d-a6f599f69115',
-			'babce997-7ff9-4837-abdc-d61d6b01ed23',
-			'8c9220f2-fbec-4022-af5e-b550bb91c6ac',
-			'eec63db9-4c81-4eaa-a8ff-e2ff33e278c2',
-			'5ca02c23-5160-4cd8-be88-09d66eeafe3b',
-			'5af1d60f-3f73-4293-aff7-3b40b5f7e764',
-			'59261a3c-e4ee-4954-b96a-032a14c05937',
-
-			'02afce67-6a86-3e49-8425-5f026b0d9be4',
-			'0bd76a95-4aa7-358a-bf78-d70657658f53',
-			'18915f53-6f96-3540-9d72-2e0400075201',
-			'19e0e2af-78c6-3e3d-942b-e4fbe27516dd',
-			'1a2a1a0a-7199-38b8-8a73-e651e2172471',
-			'1ccd0d9f-8849-32a6-941a-0d37e1001603',
-			'1ce6e12f-4352-49d1-ab21-25c725c64041',
-			'1d3f86a4-4df8-3652-adfc-dcae9e6645a5',
-			'1e0a2449-d86d-3b94-a888-9eb596f2592c',
-			'23629959-5137-384a-a8af-3f7d9cb16912',
-			'2dd66dcb-b87d-35ef-b1bf-ce8706f2c382',
-			'36ccf330-dc41-3ca1-8335-9cb1fe3ee21e',
-			'38dbd827-fedc-3ebe-919f-e64cf55ea959',
-			'398df8c0-67b1-11e7-8526-7b38dcaef614',
-			'3cf28f7f-78ff-4c1f-a197-896dea2a9595',
-			'42ad255a-99f9-11e7-b83c-9588e51488a0',
-			'4c632b1d-3d26-3d54-8dab-d1a91236fc2d',
-			'6134ca00-5e85-4054-91f0-d8274e8ad994',
-			'69837688-9a04-11e7-b83c-9588e51488a0',
-			'6a21c3e0-995c-11e7-a652-cde3f882dd7b',
-			'6d0d2fab-102e-32f8-bd3b-f2a12c454613',
-			'7156ce33-3a5a-43b9-83ce-2206337d2784',
-			'72ecae21-af5a-46db-914c-f8072d342bd2',
-			'749cb87e-6ca8-11e7-b9c7-15af748b60d0',
-			'7fce0429-54de-31d5-b511-acc9c4914eb2',
-			'852939c8-859c-361e-8514-f82f6c041580',
-			'89d15f70-640d-11e4-9803-0800200c9a66',
-			'93991a3c-0436-41bb-863e-61242e09859c',
-			'98b46b5f-17d3-40c2-8eaa-082df70c5f01',
-			'996fbb84-96d7-11e7-b83c-9588e51488a0',
-			'9b40e89c-e87b-3d4f-b72c-2cf7511d2146',
-			'a026ef35-c5d3-3fd4-8646-5e1dc1606a9a',
-			'a1af0574-eafb-41bd-aa4f-59aa2cd084c2',
-			'b16fce7e-3c92-48a3-ace0-d1af3fce71af',
-			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22',
-			'bea65a67-c2e3-3488-820a-5c21074b34e5',
-			'd2638930-7db3-11e7-ab01-a13271d1ee9c',
-			'd43c7982-97d1-11e7-b83c-9588e51488a0',
-			'd969d76e-f8f4-34ae-bc38-95cfd0884740',
-			'd9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa',
-			'dddf09c6-77a8-11e7-a3e8-60495fe6ca71',
-			'de3e1832-97cc-11e7-b83c-9588e51488a0',
-			'dee66cf5-5374-4674-9f70-90cccbc9604a',
-			'df5190e2-20f9-379b-9054-06ecfbdcb3a0',
-			'e569e23b-0c3e-3d20-8ed0-4c17b8177c05',
-			'eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0',
-			'ecdc60f0-97dc-11e7-a652-cde3f882dd7b',
-			'ef4c49fe-980e-11e7-b83c-9588e51488a0',
-			'f6da0ec5-c433-3cf5-91fb-c781fe8c370b',
-			'f7428da5-c1d2-35d7-abef-95be5f382b78',
-			'f967910f-67d5-31f7-a031-64f8af0d9cf1'
+			'a0b1c2d3-e4f5-g6h7-i9j0-k1l2m3n4o5p6', // doc/README.md:49|82
+			'z0y8x7w6-v5u4-t3s2-r1q0-p9o8n7m6l5k4', // doc/README.md:51
+			'c3e9b81a-c477-11e7-b2bb-322b2cb39656', // doc/README.md:162|174
+			'a22ff86e-ba37-11e7-9bfb-4a9c83ffa852', // doc/README.md:163|189
+			'40a86de6-b5dd-11e7-a398-73d59db9e399', // doc/README.md:245|258
+			'081b2240-ae7e-11e7-aab9-abaa44b1e130', // doc/README.md:272|285
+			'286ad07a-c415-11e7-b2bb-322b2cb39656', // doc/README.md:319|330|341|345|346|383|411|441
+			'9d5272af0a36ca429249c25899a64f88', // doc/README.md:481|481
+			'b2697f93-52d3-4d42-8409-bdf91b09e894', // doc/README.md:484|517, test/server/controllers/export.spec.js:61|80|101|119, test/server/controllers/resolve.spec.js:65|86|107|127, test/server/lib/get-all-existing-items-for-contract.spec.js:50|69|88|106
+			'315daef2-b1c1-11e7-aa26-bb002965bce8', // doc/README.md:485|495|499
+			'45bd7ff4e01052bb77a839766e1e69d9', // doc/README.md:514|514
+			'eb5982b4-b3ff-11e7-a398-73d59db9e399', // doc/README.md:518|528|532
+			'1166b19b-7ad0-4cf7-a679-3cfa3a618d76', // doc/SYNDICATION.md:137
+			'5ab2ecac-3235-4aa0-a325-f71526ace32b', // doc/SYNDICATION.md:141
+			'6b57996f-8927-416a-8d25-deeb76755798', // doc/SYNDICATION.md:145
+			'8ef593a8-eef6-448c-8560-9ca8cdca80a5', // doc/troubleshooting.md:14, test/db/pg/map-columns.spec.js:80|99|102, test/fixtures/google-spreadsheet.json:11, test/fixtures/licenceUsers.json:8, test/fixtures/userResponse.json:2, test/server/controllers/export.spec.js:42, test/server/controllers/history.spec.js:34|48|62|75|222|338|457|576, test/server/controllers/resolve.spec.js:44, test/server/controllers/translations.spec.js:50|153|311|469|629|793, test/server/controllers/unsave-by-content-id.spec.js:37|150, test/server/lib/get-all-existing-items-for-contract.spec.js:31, test/server/lib/get-history-by-contract-id.spec.js:29|43|57|70|135, test/server/middleware/check-if-new-syndication-user.spec.js:29, test/server/middleware/get-contract-by-id-from-session.spec.js:99|101|185|187, test/server/middleware/get-users-for-licence.spec.js:113
+			'4d31c9e5-eafe-4639-bba0-24d7a488b08f', // runbook.md:47
+			'john\\.q@average\\.com', // test/db/pg/map-columns.spec.js:27, test/fixtures/contractProfile.json:7
+			'0c56a4f2-6bc5-11e7-bfeb-33fe0c5b7eaa', // test/db/pg/map-columns.spec.js:76|95, test/server/controllers/history.spec.js:31|91|101|109|114, test/server/lib/get-history-by-contract-id.spec.js:26
+			'c3391af1-0d46-4ddc-a922-df7c49cf1552', // test/db/pg/map-columns.spec.js:84|104, test/server/controllers/history.spec.js:36|50|64|77|277|395|514|633, test/server/controllers/translations.spec.js:114|222|380|540|698|862, test/server/lib/get-history-by-contract-id.spec.js:31|45|59|72
+			'9807a4b6dcb3ce1188593759dd6818cd', // test/db/pg/map-columns.spec.js:86|86|106|106, test/server/controllers/history.spec.js:38|38, test/server/controllers/unsave-by-content-id.spec.js:32|32|145|145, test/server/lib/get-history-by-contract-id.spec.js:33|33
+			'foo@bar\\.com', // test/db/toPutItem.spec.js:69, test/queue/message-queue-event.spec.js:86|143|181|226|260|292|330|375, test/queue/publish.spec.js:98, test/server/controllers/download-by-content-id.spec.js:97|187, test/server/controllers/export.spec.js:189|267, test/server/controllers/save-by-content-id.spec.js:94, test/server/controllers/unsave-by-content-id.spec.js:111|222, test/server/controllers/update-download-format.spec.js:75|93|109, test/server/controllers/user-status.spec.js:97|127, test/server/lib/bundle-content.spec.js:101|122|253|274, test/worker/persist.spec.js:44, test/worker/sync/db-persist/mail-contributor.spec.js:76|159, test/worker/sync/db-persist/spoor-publish.spec.js:75, test/worker/sync/db-persist/upsert-history.spec.js:60
+			'2778b97a-5bc9-11e7-9bc8-8055f264aa8b', // test/fixtures/2778b97a-5bc9-11e7-9bc8-8055f264aa8b.json:2|12|20
+			'0592f436-5c0c-11e7-2b35-7545c1789969', // test/fixtures/2778b97a-5bc9-11e7-9bc8-8055f264aa8b.json:4|14
+			'dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54', // test/fixtures/2778b97a-5bc9-11e7-9bc8-8055f264aa8b.json:13, test/fixtures/80d634ea-fa2b-46b5-886f-1418c6445182.json:12, test/fixtures/b59dff10-3f7e-11e7-9d56-25f963e998b2.json:13, test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:15, test/fixtures/d7bf1822-ec58-4a8e-a669-5cbcc0d6a1b2.json:13, test/fixtures/dbe4928a-5bec-11e7-b553-e2df1b0c3220.json:13, test/server/controllers/history.spec.js:102|128|157|183, test/server/lib/decorate-article.spec.js:26
+			'80d634ea-fa2b-46b5-886f-1418c6445182', // test/fixtures/80d634ea-fa2b-46b5-886f-1418c6445182.json:2|11|53, test/server/lib/bundle-content.spec.js:197, test/server/lib/fetch-content-by-id.spec.js:41|59, test/server/lib/resolve/id.spec.js:15
+			'd0842750-9903-4bf9-2ee7-f3d98afabc1e', // test/fixtures/80d634ea-fa2b-46b5-886f-1418c6445182.json:13
+			'b59dff10-3f7e-11e7-9d56-25f963e998b2', // test/fixtures/article.html:6, test/fixtures/article.plain:12, test/fixtures/b59dff10-3f7e-11e7-9d56-25f963e998b2.json:2|12|20, test/server/controllers/export.spec.js:62|73, test/server/controllers/resolve.spec.js:78, test/server/controllers/save-by-content-id.spec.js:30, test/server/lib/convert-article.spec.js:15, test/server/lib/decorate-article.spec.js:15|25|33, test/server/lib/fetch-content-by-id.spec.js:42|60, test/server/lib/to-plain-text.spec.js:22|30
+			'16a642f4-3f84-11e7-1cd0-1ef14f87a411', // test/fixtures/b59dff10-3f7e-11e7-9d56-25f963e998b2.json:4|14, test/server/lib/decorate-article.spec.js:17|27
+			'faf86fbc-0009-11df-8626-00144feabdc0', // test/fixtures/b59dff10-3f7e-11e7-9d56-25f963e998b2.json:21, test/server/lib/decorate-article.spec.js:34, test/server/lib/get-word-count.spec.js:61
+			'c7923fba-1d31-39fd-82f0-ba1822ef20d2', // test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:2|12, test/server/controllers/export.spec.js:43|54|81|92|102|112, test/server/controllers/resolve.spec.js:57|98|119, test/server/lib/fetch-content-by-id.spec.js:43|61
+			'34b704a0-54d7-11e7-9fed-c19e2700005f', // test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:4|5
+			'b4fac748-a2b1-4b7d-8e1f-03ba743ff717', // test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:14
+			'00004ffc-004e-50ad-0337-456ae1b1861c', // test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:17
+			'6ce05235-c102-48b9-a886-95dbd7f40419', // test/fixtures/c7923fba-1d31-39fd-82f0-ba1822ef20d2.json:19
+			'42ad255a-99f9-11e7-b83c-9588e51488a0', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:2|3|10|86|87|452|453|454, test/fixtures/content/items.json:3|4|11|87|88|453|454|455, test/server/controllers/download-by-content-id.spec.js:38, test/server/controllers/resolve.spec.js:32|45|46|247, test/server/controllers/unsave-by-content-id.spec.js:35|36|58|65|66|67|78|80|82|85|148|149|167|174|175|176|188|190|192|195, test/server/lib/download/article.spec.js:47, test/server/lib/download/index.spec.js:37, test/server/lib/enrich/article.js:23, test/server/lib/enrich/index.js:25, test/server/lib/format-article-xml.spec.js:53, test/server/lib/get-content-by-id.spec.js:47, test/server/lib/get-content.spec.js:23
+			'd2638930-7db3-11e7-ab01-a13271d1ee9c', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:38|49|50|56|60|84|85|481, test/fixtures/content/items.json:39|50|51|57|61|85|86|482
+			'69837688-9a04-11e7-b83c-9588e51488a0', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:68|69|71|75, test/fixtures/content/items.json:69|70|72|76
+			'ad26302e-9879-11e7-8c5c-c8d8fa6961bb', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:95, test/fixtures/content/items.json:96
+			'de3e1832-97cc-11e7-b83c-9588e51488a0', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:102|113|116, test/fixtures/content/items.json:103|114|117
+			'19b95057-4614-45fb-9306-4d54049354db', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:120, test/fixtures/content/items.json:121
+			'0501c122-995c-11e7-8c5c-c8d8fa6961bb', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:132, test/fixtures/content/items.json:133
+			'd17153e9-f07d-49ad-8dbd-4cb23d6bbc9b', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:139|143|144|207|211|212, test/fixtures/content/items.json:140|144|145|208|212|213
+			'd43c7982-97d1-11e7-b83c-9588e51488a0', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:146|157|160, test/fixtures/content/items.json:147|158|161
+			'1d556016-ad16-4fe7-8724-42b3fb15ad28', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:164, test/fixtures/content/items.json:165
+			'b9d7e924-996a-11e7-8c5c-c8d8fa6961bb', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:182, test/fixtures/content/items.json:183
+			'6a21c3e0-995c-11e7-a652-cde3f882dd7b', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:189|200|203, test/fixtures/content/items.json:190|201|204
+			'6b683eff-56c3-43d9-acfc-7511d974fc01', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:222|224, test/fixtures/content/items.json:223|225
+			'04126152-5bef-4dda-86bf-81f66c00a342', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:238|240, test/fixtures/content/items.json:239|241
+			'c91b1fad-1097-468b-be82-9a8ff717d54c', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:254|256, test/fixtures/content/items.json:255|257
+			'f7428da5-c1d2-35d7-abef-95be5f382b78', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:270|272|282|283, test/fixtures/content/items.json:271|273|283|284
+			'a579350c-61ce-4c00-97ca-ddaa2e0cacf6', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:286|288|299|300|374|376|387|388, test/fixtures/content/items.json:287|289|300|301|375|377|388|389
+			'466a4700-307f-47cc-83f1-c5f97a172232', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:303|305|315|316|435|437|447|448|467|471|472, test/fixtures/content/items.json:304|306|316|317|436|438|448|449|468|472|473
+			'dd4b519f-e896-4322-8f77-25c936eb9d32', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:319|321|392|394, test/fixtures/content/items.json:320|322|393|395
+			'33b4cf11-6854-4dc5-aadb-f0a671da0753', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:335|337|408|410, test/fixtures/content/items.json:336|338|409|411
+			'049291ca-c558-4b3d-ac99-cdc2e19dfc46', // test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json:357|359, test/fixtures/content/items.json:358|360
+			'52be3c0c-7831-11e7-a3e8-60495fe6ca71', // test/fixtures/content/52be3c0c-7831-11e7-a3e8-60495fe6ca71.json:2|3|6|38|39|58, test/fixtures/content/es/52be3c0c-7831-11e7-a3e8-60495fe6ca71.json:2|14|18|19|25|26, test/server/controllers/translations.spec.js:31|35, test/server/lib/resolve/lang/es/previewText.spec.js:23
+			'32d8f4b0-5d58-434d-b578-337486e9f714', // test/fixtures/content/52be3c0c-7831-11e7-a3e8-60495fe6ca71.json:11
+			'260b270a-723d-11e7-93ff-99f383b09ff9', // test/fixtures/content/52be3c0c-7831-11e7-a3e8-60495fe6ca71.json:28
+			'93991a3c-0436-41bb-863e-61242e09859c', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:2|21|22, test/fixtures/content/items.json:1491|1510|1511, test/server/controllers/resolve.spec.js:37|317, test/server/lib/enrich/index.js:30, test/server/lib/enrich/podcast.js:28, test/server/lib/format-article-xml.spec.js:58, test/server/lib/get-content-by-id.spec.js:113|170, test/server/lib/get-content.spec.js:28
+			'thehitsthatshooktheworld', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:3|26, test/fixtures/content/items.json:1492|1515
+			'72ecae21-af5a-46db-914c-f8072d342bd2', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:31|32|100|101|117|118, test/fixtures/content/items.json:1520|1521|1589|1590|1606|1607
+			'1d3f86a4-4df8-3652-adfc-dcae9e6645a5', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:43|45|111|113|129|131, test/fixtures/content/items.json:1532|1534|1600|1602|1618|1620
+			'02afce67-6a86-3e49-8425-5f026b0d9be4', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:48|49, test/fixtures/content/items.json:1537|1538
+			'f967910f-67d5-31f7-a031-64f8af0d9cf1', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:65|66, test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:76|78, test/fixtures/content/items.json:1554|1555
+			'bea65a67-c2e3-3488-820a-5c21074b34e5', // test/fixtures/content/93991a3c-0436-41bb-863e-61242e09859c.json:82|83, test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:82|83, test/fixtures/content/items.json:1428|1429|1571|1572
+			'98b46b5f-17d3-40c2-8eaa-082df70c5f01', // test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:2|21|22, test/fixtures/content/items.json:1348|1367|1368, test/server/controllers/resolve.spec.js:36|303, test/server/lib/download/index.spec.js:39, test/server/lib/download/podcast.spec.js:52, test/server/lib/enrich/index.js:29, test/server/lib/enrich/podcast.js:27, test/server/lib/format-article-xml.spec.js:57, test/server/lib/get-content-by-id.spec.js:112|169, test/server/lib/get-content.spec.js:27
+			'1ccd0d9f-8849-32a6-941a-0d37e1001603', // test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:31|32|100|101|117|118, test/fixtures/content/items.json:1377|1378|1446|1447|1463|1464
+			'dee66cf5-5374-4674-9f70-90cccbc9604a', // test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:43|45|111|113|129|131, test/fixtures/content/items.json:1389|1391|1457|1459|1475|1477
+			'd969d76e-f8f4-34ae-bc38-95cfd0884740', // test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:48|49, test/fixtures/content/items.json:1394|1395
+			'89d15f70-640d-11e4-9803-0800200c9a66', // test/fixtures/content/98b46b5f-17d3-40c2-8eaa-082df70c5f01.json:65|66|77|79, test/fixtures/content/items.json:1411|1412|1423|1425
+			'a1af0574-eafb-41bd-aa4f-59aa2cd084c2', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:2|3|8|35|66|259|260|261, test/fixtures/content/items.json:1047|1048|1053|1080|1111|1304|1305|1306, test/server/controllers/download-by-content-id.spec.js:115, test/server/controllers/resolve.spec.js:35|128|129|289, test/server/lib/enrich/index.js:28, test/server/lib/enrich/video.js:28, test/server/lib/format-article-xml.spec.js:56, test/server/lib/get-content-by-id.spec.js:111|168, test/server/lib/get-content.spec.js:26
+			'996fbb84-96d7-11e7-b83c-9588e51488a0', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:16|17, test/fixtures/content/items.json:1061|1062
+			'3cf28f7f-78ff-4c1f-a197-896dea2a9595', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:68|288, test/fixtures/content/items.json:1113|1333
+			'6d0d2fab-102e-32f8-bd3b-f2a12c454613', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:78|80|91|92|174|176|187|188|241|243|254|255|274|278|279, test/fixtures/content/items.json:1123|1125|1136|1137|1219|1221|1232|1233|1286|1288|1299|1300|1319|1323|1324
+			'6da31a37-691f-4908-896f-2829ebe2309e', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:95|97|157|159, test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:94|96|183|185, test/fixtures/content/items.json:611|613|700|702|1140|1142|1202|1204
+			'08c3aeaf-259b-436a-83d9-7253c78540fc', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:112|114|192|194, test/fixtures/content/items.json:1157|1159|1237|1239
+			'b1d025bc-56d5-4420-ae8c-49c0c02cc816', // test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json:134|136|214|216, test/fixtures/content/items.json:1179|1181|1259|1261
+			'b16fce7e-3c92-48a3-ace0-d1af3fce71af', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:2|3|8|47|78|163|164|165, test/fixtures/content/items.json:842|843|848|887|918|1003|1004|1005, test/server/controllers/resolve.spec.js:34|87|88|108|109|275, test/server/lib/download/index.spec.js:38, test/server/lib/download/video.spec.js:52, test/server/lib/enrich/index.js:27, test/server/lib/enrich/video.js:27, test/server/lib/format-article-xml.spec.js:55, test/server/lib/get-content-by-id.spec.js:110|167, test/server/lib/get-content.spec.js:25
+			'749cb87e-6ca8-11e7-b9c7-15af748b60d0', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:16|17, test/fixtures/content/items.json:856|857
+			'dddf09c6-77a8-11e7-a3e8-60495fe6ca71', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:20|21, test/fixtures/content/items.json:860|861
+			'd9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:24|25, test/fixtures/content/items.json:864|865
+			'398df8c0-67b1-11e7-8526-7b38dcaef614', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:28|29, test/fixtures/content/items.json:868|869
+			'7156ce33-3a5a-43b9-83ce-2206337d2784', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:80|192, test/fixtures/content/items.json:920|1032
+			'596c35ec-bdb3-409a-83fb-717ecd3dc029', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:90|92|124|126, test/fixtures/content/items.json:930|932|964|966
+			'c47f4dfc-6879-4e95-accf-ca8cbe6a1f69', // test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json:107|109|146|148|178, test/fixtures/content/items.json:947|949|986|988|1018
+			'b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:2|3|6|55|56|244|248|249, test/fixtures/content/es/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:2|14|18|19|25|26, test/fixtures/s3-events/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.create.json:14, test/fixtures/s3-events/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.delete.json:14, test/fixtures/translations/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:2, test/server/controllers/translations.spec.js:32|36, test/server/lib/resolve/lang/es/previewText.spec.js:31, test/worker/sync/content-es/upsert-content.spec.js:51|57|73|84|96|105
+			'a912eb98-8759-11e7-bf50-e1c239b45787', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:31|37
+			'df5190e2-20f9-379b-9054-06ecfbdcb3a0', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:59|61|210|212
+			'852939c8-859c-361e-8514-f82f6c041580', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:93|95
+			'5ea997c8-1de2-3add-8e63-8639fc2459c9', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:110|112
+			'e569e23b-0c3e-3d20-8ed0-4c17b8177c05', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:126|128|138|140
+			'8a086a54-ea48-3a52-bd3c-5821430c2132', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:143|145
+			'8a9d1cd8-f4da-38d6-a4eb-195d6a41d902', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:159|161
+			'2dd66dcb-b87d-35ef-b1bf-ce8706f2c382', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:176|178
+			'b83df96a-67c7-3618-9fc1-db357bf775eb', // test/fixtures/content/b6e54ea4-86c4-11e7-8bb1-5ba57d47eff7.json:193|195|204|206|228|230|239|241
+			'ef4c49fe-980e-11e7-b83c-9588e51488a0', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:2|3|10|71|72|246|247|248, test/fixtures/content/items.json:519|520|527|588|589|763|764|765, test/server/controllers/resolve.spec.js:33|66|67|261, test/server/lib/enrich/article.js:24, test/server/lib/enrich/index.js:26, test/server/lib/format-article-xml.spec.js:54, test/server/lib/get-content-by-id.spec.js:48, test/server/lib/get-content.spec.js:24
+			'ecdc60f0-97dc-11e7-a652-cde3f882dd7b', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:38|49|50|55|59|68|69|288, test/fixtures/content/items.json:555|566|567|572|576|585|586|805, test/server/lib/format-article-xml.spec.js:24
+			'84cf4073-a674-4a93-aef9-dcc1832a65cb', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:76|78|90|91, test/fixtures/content/items.json:593|595|607|608
+			'0b83bc44-4a55-4958-882e-73ba6b2b0aa6', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:111|113, test/fixtures/content/items.json:628|630
+			'f12aa89a-5506-4a68-aff6-4ce78d0e709f', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:127|129|228|230|275, test/fixtures/content/items.json:644|646|745|747|792
+			'6b32f2c1-da43-4e19-80b9-8aef4ab640d7', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:144|146, test/fixtures/content/items.json:661|663
+			'14c63939-4e28-4aaa-bf44-af570a20990e', // test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json:160|162|201|203|261, test/fixtures/content/items.json:677|679|718|720|778
+			'f743871c-3499-4844-9d2b-685fcd94f9c7', // test/fixtures/contractResponse.json:15|106|138
+			'f743871c-3499-4844-9d2b-685fcd94f9c8', // test/fixtures/contractResponse.json:46|75|170|200|230|260
+			'd7bf1822-ec58-4a8e-a669-5cbcc0d6a1b2', // test/fixtures/d7bf1822-ec58-4a8e-a669-5cbcc0d6a1b2.json:2|12|56, test/server/lib/bundle-content.spec.js:45, test/server/lib/fetch-content-by-id.spec.js:44|62
+			'de2390cd-46a1-4c58-2914-f5f50e13f766', // test/fixtures/d7bf1822-ec58-4a8e-a669-5cbcc0d6a1b2.json:14
+			'dbe4928a-5bec-11e7-b553-e2df1b0c3220', // test/fixtures/dbe4928a-5bec-11e7-b553-e2df1b0c3220.json:2|12|20, test/server/controllers/export.spec.js:120|130, test/server/controllers/resolve.spec.js:139
+			'72281190-5be8-11e7-2b35-7545c1789969', // test/fixtures/dbe4928a-5bec-11e7-b553-e2df1b0c3220.json:4|14
+			'8ef593a8-eef6-448c-8560-9ca8cdca80a6', // test/fixtures/google-spreadsheet.json:19
+			'd4efba32-d2ca-11e6-b06b-680c49b4b4c0', // test/fixtures/s3-events/d4efba32-d2ca-11e6-b06b-680c49b4b4c0.create.json:14, test/fixtures/s3-events/d4efba32-d2ca-11e6-b06b-680c49b4b4c0.delete.json:14, test/fixtures/translations/d4efba32-d2ca-11e6-b06b-680c49b4b4c0.json:2
+			'167e9de0f286d5d771a89b864c053ea8', // test/health/db-backups.spec.js:40|40
+			'095ffdbf50ee4041ee18ed9077216844', // test/server/controllers/export.spec.js:39|39, test/server/controllers/resolve.spec.js:41|41, test/server/lib/get-all-existing-items-for-contract.spec.js:28|28
+			'6feabf0d4eed16682bfbd6d3560a45ee', // test/server/controllers/export.spec.js:58|58, test/server/controllers/resolve.spec.js:62|62, test/server/lib/get-all-existing-items-for-contract.spec.js:47|47
+			'8d1beddb5cc7ed98a61fc28934871b35', // test/server/controllers/export.spec.js:77|77|98|98, test/server/controllers/resolve.spec.js:83|83|104|104, test/server/lib/get-all-existing-items-for-contract.spec.js:66|66|85|85
+			'ee0981e4bebd818374a6c1416029656f', // test/server/controllers/export.spec.js:116|116, test/server/controllers/resolve.spec.js:124|124, test/server/lib/get-all-existing-items-for-contract.spec.js:103|103
+			'0aaee458-6c6e-11e7-bfeb-33fe0c5b7eaa', // test/server/controllers/history.spec.js:45|117|127|135|140, test/server/lib/get-history-by-contract-id.spec.js:40
+			'f55885427fa5f8c3e2b90204a6e6b0c7', // test/server/controllers/history.spec.js:52|52, test/server/lib/get-history-by-contract-id.spec.js:47|47
+			'74447ca2-6b0b-11e7-bfeb-33fe0c5b7eaa', // test/server/controllers/history.spec.js:59|143|156|164|169, test/server/lib/get-history-by-contract-id.spec.js:54
+			'4eff4aba81093b44d2a71c36fc8e9898', // test/server/controllers/history.spec.js:65|65, test/server/lib/get-history-by-contract-id.spec.js:60|60
+			'eaef2e2c-6c61-11e7-b9c7-15af748b60d0', // test/server/controllers/history.spec.js:72|172|182|190|195, test/server/lib/get-history-by-contract-id.spec.js:67
+			'c71c4e6cf5183996a34235bf50bc0e1d', // test/server/controllers/history.spec.js:78|78, test/server/lib/get-history-by-contract-id.spec.js:73|73
+			'ef05ef34-653e-11e7-0400-0461ef5f0ab7', // test/server/controllers/history.spec.js:93|103
+			'55c4033a-6c6c-11e7-27a1-8235aeffcb99', // test/server/controllers/history.spec.js:119|129
+			'5558218c-6baa-11e7-218d-a464d62fd5e3', // test/server/controllers/history.spec.js:145|158
+			'a6652138-6c68-11e7-27a1-8235aeffcb99', // test/server/controllers/history.spec.js:174|184
+			'eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0', // test/server/lib/format-article-xml.spec.js:28
+			'02c03200-86dc-11e7-bf50-e1c239b45787', // test/server/lib/get-all-existing-items-for-contract.spec.js:32|43|70|80|89|99
+			'491cf75e-51d2-11e7-a1f2-db19572361bb', // test/server/lib/get-all-existing-items-for-contract.spec.js:51|62
+			'b3ec55b0-7dd4-11e7-9108-edda0bcbc928', // test/server/lib/get-all-existing-items-for-contract.spec.js:107|117
+			'fakenews-fa2b-46b5-886f-1418c6445182', // test/server/lib/get-content-by-id.spec.js:217
+			'fakenews-3f7e-11e7-9d56-25f963e998b2', // test/server/lib/get-content-by-id.spec.js:218
+			'fakenews-1d31-39fd-82f0-ba1822ef20d2', // test/server/lib/get-content-by-id.spec.js:219
+			'fakenews-ec58-4a8e-a669-5cbcc0d6a1b2' // test/server/lib/get-content-by-id.spec.js:220
 		]
 	}
 };

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -33,6 +33,11 @@ module.exports = exports = function article(content, format) {
 
 	content.hasGraphics = Boolean(content.contentStats && content.contentStats.graphics);
 
+	const countOfGraphics = content.contentStats && content.contentStats.graphics && content.contentStats.graphics;
+	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').lenght : 0;
+
+	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : null;
+
 	if (content.bodyHTML) {
 		content.document = formatArticleXML(`<body>${content.bodyHTML}</body>`);
 

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -39,7 +39,7 @@ module.exports = exports = function article(content, format) {
 	// can't be, the answer to this is 'no'
 	const atLeastOneGraphicCantBeShared = content.embeds && content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).some(item => item.canBeSyndicated !== 'yes');
 
-	content.canAllGraphicsBeSyndicated = Boolean(atLeastOneGraphicCantBeShared);
+	content.canAllGraphicsBeSyndicated = !atLeastOneGraphicCantBeShared;
 
 	if (content.bodyHTML) {
 		content.document = formatArticleXML(`<body>${content.bodyHTML}</body>`);

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -36,7 +36,7 @@ module.exports = exports = function article(content, format) {
 	const countOfGraphics = content.contentStats && content.contentStats.graphics && content.contentStats.graphics;
 	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').lenght : 0;
 
-	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : null;
+	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : false;
 
 	if (content.bodyHTML) {
 		content.document = formatArticleXML(`<body>${content.bodyHTML}</body>`);

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -33,10 +33,13 @@ module.exports = exports = function article(content, format) {
 
 	content.hasGraphics = Boolean(content.contentStats && content.contentStats.graphics);
 
-	const countOfGraphics = content.contentStats && content.contentStats.graphics;
-	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic') && embed.canBeSyndicated === 'yes').length : 0;
+	// Currently embeds can have more than one item for each picture - for different screen sizes
+	// We are assuming that canBeSyndicated is the same for all sizes of a picture
+	// We are asking if ALL Graphics can be syndicated, which means as long as at least one item
+	// can't be, the answer to this is 'no'
+	const atLeastOneGraphicCantBeShared = content.embeds && content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).some(item => item.canBeSyndicated !== 'yes');
 
-	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : false;
+	content.canAllGraphicsBeSyndicated = Boolean(atLeastOneGraphicCantBeShared);
 
 	if (content.bodyHTML) {
 		content.document = formatArticleXML(`<body>${content.bodyHTML}</body>`);

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -34,7 +34,7 @@ module.exports = exports = function article(content, format) {
 	content.hasGraphics = Boolean(content.contentStats && content.contentStats.graphics);
 
 	const countOfGraphics = content.contentStats && content.contentStats.graphics && content.contentStats.graphics;
-	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').lenght : 0;
+	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').length : 0;
 
 	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : false;
 

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -33,7 +33,7 @@ module.exports = exports = function article(content, format) {
 
 	content.hasGraphics = Boolean(content.contentStats && content.contentStats.graphics);
 
-	const countOfGraphics = content.contentStats && content.contentStats.graphics && content.contentStats.graphics;
+	const countOfGraphics = content.contentStats && content.contentStats.graphics;
 	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').length : 0;
 
 	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : false;

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -34,7 +34,7 @@ module.exports = exports = function article(content, format) {
 	content.hasGraphics = Boolean(content.contentStats && content.contentStats.graphics);
 
 	const countOfGraphics = content.contentStats && content.contentStats.graphics;
-	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).filter(embed => embed.canBeSyndicated === 'yes').length : 0;
+	const countOfSharableGraphics = content.embeds ? content.embeds.filter(embed => embed && embed.type.endsWith('Graphic') && embed.canBeSyndicated === 'yes').length : 0;
 
 	content.canAllGraphicsBeSyndicated = countOfGraphics > 0 ? countOfSharableGraphics < countOfGraphics : false;
 

--- a/server/lib/resolve/canAllGraphicsBeSyndicated.js
+++ b/server/lib/resolve/canAllGraphicsBeSyndicated.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = exports = item => item;

--- a/server/lib/resolve/hasGraphics.js
+++ b/server/lib/resolve/hasGraphics.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = exports = item => item;

--- a/server/lib/resolve/index.js
+++ b/server/lib/resolve/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
 exports.id = require('./id');
+exports.canAllGraphicsBeSyndicated = require('./canAllGraphicsBeSyndicated');
 exports.canDownload = require('./canDownload');
 exports.canBeSyndicated = require('./canBeSyndicated');
 exports.downloaded = require('./downloaded');
 exports.embargoPeriod = require('./embargoPeriod');
+exports.hasGraphics = require('./hasGraphics');
 exports.lang = require('./lang');
 exports.publishedDate = require('./publishedDate');
 exports.publishedDateDisplay = require('./publishedDateDisplay');

--- a/server/lib/syndicate-content.js
+++ b/server/lib/syndicate-content.js
@@ -70,5 +70,10 @@ function tidy(item, includeBody) {
 		delete item.fileName;
 	}
 
+	if (item.hasGraphics === undefined){
+		delete item.canAllGraphicsBeSyndicated;
+		delete item.hasGraphics;
+	}
+
 	return item;
 }

--- a/server/lib/syndicate-content.js
+++ b/server/lib/syndicate-content.js
@@ -70,7 +70,7 @@ function tidy(item, includeBody) {
 		delete item.fileName;
 	}
 
-	if (item.hasGraphics === undefined){
+	if (item.type !== 'article'){
 		delete item.canAllGraphicsBeSyndicated;
 		delete item.hasGraphics;
 	}

--- a/test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json
+++ b/test/fixtures/content/42ad255a-99f9-11e7-b83c-9588e51488a0.json
@@ -1,19 +1,22 @@
 {
   "id": "42ad255a-99f9-11e7-b83c-9588e51488a0",
-  "webUrl": "http://www.ft.com/cms/s/42ad255a-99f9-11e7-b83c-9588e51488a0.html",
+  "webUrl": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
   "title": "Pound leaps to highest level since Brexit vote",
   "alternativeTitles": {
     "promotionalTitle": "Pound leaps to highest level since Brexit vote"
   },
+  "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
   "provenance": [
-    "http://api.ft.com/internalcontent/42ad255a-99f9-11e7-b83c-9588e51488a0"
+    "https://api.ft.com/internalcontent/42ad255a-99f9-11e7-b83c-9588e51488a0"
   ],
   "byline": "Roger Blitz and Kate Allen",
-  "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
-  "publishedDate": "2017-09-15T10:38:16.000Z",
+  "publishedDate": "2017-09-15T15:48:53.000Z",
   "firstPublishedDate": "2017-09-15T10:25:00.000Z",
-  "publishReference": "tid_bl0dhgy9yi",
-  "curatedRelatedContent": [ ],
+  "publishReference": "SYNTHETIC-REQ-MONtid_8mMknhpoIs_carousel_1534772577",
+  "bodyText": "The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.\n\nGertjan Vlieghe, a member of the bank’s Monetary Policy Committee who has previously been cautious about tightening policy, said “we are approaching the moment when the bank rate may need to rise”.\n\nComing a day after the MPC kept rates on hold but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the pound’s rally.\n\nInvestors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 4 basis points to 0.42 per cent, after earlier hitting a session high above 0.48 per cent. That was the highest level since the week before the EU referendum in June last year.\n\nUK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.1 per cent.\n\n“The BoE really have lined up the market for a hike,” said Jordan Rochester, a currency strategist at Nomura.\n\nSterling was last trading at $1.3589 after earlier hitting a day high of $1.3615 — this 1.4 per cent advance leaves sterling up about 3 per cent against the dollar on the week week, which began with stronger than expected inflation figures.\n\nThe currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.\n\nAlthough the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision — and Mr Vlieghe’s speech today — is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so.\n\n“The possibility of a November or February hike is real, we think,” analysts at Bank of America Merrill Lynch noted. “That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.”\n\nBefore Mr Vlieghe’s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have reservations about the shift from the bank.\n\nMr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have “a larger impact on the economy than we have seen so far”.\n\nDavid Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was “deliberately set to stabilise further the pound sterling”.\n\nThe currency’s weakness has been a strong driver of inflation and the pound’s renewed strength “will limit the inflation overshoot”.\n\nWhile strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained “many doubters” in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.\n\n“The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,” said Mr Rochester.",
+  "curatedRelatedContent": [],
+  "containedIn": [],
+  "canBeDistributed": "yes",
   "canBeSyndicated": "yes",
   "comments": {
     "enabled": true
@@ -24,58 +27,244 @@
     "scoop": false
   },
   "realtime": false,
+  "editorialDesk": "/FT/WorldNews",
   "originatingParty": "FT",
-  "_lastUpdatedDateTime": "2017-09-15T11:08:41.343Z",
+  "_lastUpdatedDateTime": "2020-09-04T05:12:41.636Z",
+  "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
   "type": "article",
   "accessLevel": "subscribed",
-  "topper": { },
-  "leadImages": [ ],
-  "containedIn": [ ],
+  "topper": {},
   "mainImage": {
+    "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
     "title": "",
     "description": "LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer £10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer £20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)",
-    "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+    "copyright": "© Getty",
     "width": 2048,
     "height": 1152,
-    "ratio": 1.7777777777777777,
+    "ratio": 1.77778,
     "aspectRatio": 0.5625
   },
-  "bodyHTML": "<figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" alt=\"\" role=\"presentation\" width=\"2048\" height=\"1152\" data-copyright=\"© Getty\"><figcaption class=\"n-content-image__caption\">© Getty</figcaption></figure><p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p><p>Gertjan Vlieghe, a member of the <a href=\"/content/36ccf330-dc41-3ca1-8335-9cb1fe3ee21e\">bank’s Monetary Policy Committee</a> who has previously been cautious about tightening policy, said “we are approaching the moment when the bank rate may need to rise”.</p><p>Coming a day after the MPC kept <a href=\"/content/f6da0ec5-c433-3cf5-91fb-c781fe8c370b\">rates</a> on hold, but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the <a href=\"https://www.ft.com/topics/themes/Sterling\">pound</a>’s rally. </p><p>Investors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 10 basis points to 0.47 per cent. That is the highest level since the week before the <a href=\"https://www.ft.com/brexit\">EU referendum</a> in June last year.</p><p>UK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.3 per cent.</p><p>“The BoE really have lined up the market for a hike,” said Jordan Rochester, a currency strategist at Nomura.</p><figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0\" alt=\"\" role=\"presentation\" data-image-type=\"graphic\" width=\"600\" height=\"396\"></figure><p>Friday’s 1.3 per cent advance leaves sterling up almost 3 per cent against the dollar this week, which began with stronger than expected inflation figures. The currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.</p><p>Although the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision — and Mr Vlieghe’s speech today — is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so. </p><p>“The possibility of a November or February hike is real, we think,” analysts at Bank of America Merrill Lynch noted. “That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.”</p><aside class=\"n-content-recommended\" role=\"complementary\"><h3 class=\"n-content-recommended__title\">Recommended</h3><ul><li><a href=\"/content/de3e1832-97cc-11e7-b83c-9588e51488a0\">Will UK economy be turbocharged by sterling fall?</a></li><li><a href=\"/content/d43c7982-97d1-11e7-b83c-9588e51488a0\">The Bank of England’s bark is loud but it has no bite</a></li><li><a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">Bank of England’s interest rate rhetoric divides opinion</a></li></ul></aside><p>Before Mr Vlieghe’s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have <a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">reservations</a> about the shift from the bank.</p><p>Mr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have “a larger impact on the economy than we have seen so far”.</p><p>David Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was “deliberately set to stabilise further the pound sterling”.</p><p>The currency’s weakness has been a strong driver of inflation and the pound’s renewed strength “will limit the inflation overshoot”.</p><p>While strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained “many doubters” in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.</p><p>“The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,” said Mr Rochester.</p>",
-  "contentStats": {
-    "relatedBoxes": 0,
-    "pullQuotes": 0,
-    "pullQuotesWithImages": 0,
-    "bigNumbers": 0,
-    "images": 2,
-    "responsiveImages": 0,
-    "graphics": 1,
-    "videos": 0,
-    "internalVideos": 0,
-    "externalVideos": 0,
-    "subheadings": 0,
-    "curatedRecommended": 1,
-    "layouts": 0,
-    "layoutSlots": 0,
-    "infoBox": 0
-  },
+  "embeds": [
+    {
+      "apiUrl": "https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+      "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+      "canBeSyndicated": "no",
+      "copyright": {
+        "notice": "© Getty"
+      },
+      "firstPublishedDate": "2017-09-15T10:58:00.000Z",
+      "id": "d2638930-7db3-11e7-ab01-a13271d1ee9c",
+      "identifiers": [
+        {
+          "authority": "http://api.ft.com/system/FTCOM-METHODE",
+          "identifierValue": "d2638930-7db3-11e7-ab01-a13271d1ee9c"
+        }
+      ],
+      "publishReference": "tid_btvrvczuwc",
+      "publishedDate": "2017-09-15T10:58:00.000Z",
+      "type": "http://www.ft.com/ontology/content/Image"
+    },
+    {
+      "apiUrl": "https://api.ft.com/content/69837688-9a04-11e7-b83c-9588e51488a0",
+      "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0",
+      "firstPublishedDate": "2017-09-15T11:07:00.000Z",
+      "id": "69837688-9a04-11e7-b83c-9588e51488a0",
+      "identifiers": [
+        {
+          "authority": "http://api.ft.com/system/FTCOM-METHODE",
+          "identifierValue": "69837688-9a04-11e7-b83c-9588e51488a0"
+        }
+      ],
+      "publishReference": "tid_f0y4netvt5",
+      "publishedDate": "2017-09-15T11:07:00.000Z",
+      "type": "http://www.ft.com/ontology/content/Graphic",
+      "canBeSyndicated": "verify"
+    }
+  ],
+  "bodyHTML": "\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-id=\"https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" alt=\"LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer &#xA3;10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer &#xA3;20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)\" width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Getty\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Getty\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure>\n\t\t<p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p><p>Gertjan Vlieghe, a member of the <a href=\"/content/36ccf330-dc41-3ca1-8335-9cb1fe3ee21e\">bank&#x2019;s Monetary Policy Committee</a> who has previously been cautious about tightening policy, said &#x201C;we are approaching the moment when the bank rate may need to rise&#x201D;.</p><p>Coming a day after the MPC kept <a href=\"/content/f6da0ec5-c433-3cf5-91fb-c781fe8c370b\">rates</a> on hold but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the <a href=\"https://www.ft.com/topics/themes/Sterling\">pound</a>&#x2019;s rally. </p><p>Investors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 4 basis points to 0.42 per cent, after earlier hitting a session high above 0.48 per cent. That was the highest level since the week before the <a href=\"https://www.ft.com/brexit\">EU referendum</a> in June last year.</p><p>UK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.1 per cent.</p><p>&#x201C;The BoE really have lined up the market for a hike,&#x201D; said Jordan Rochester, a currency strategist at Nomura.</p>\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0\" data-id=\"https://api.ft.com/content/69837688-9a04-11e7-b83c-9588e51488a0\" data-image-type=\"graphic\" data-original-image-width=\"600\" data-original-image-height=\"396\" alt=\"A graphic with no description\" width=\"600\" height=\"396\">\n\t\t\t\t\n\t\t\t</figure>\n\t\t<p>Sterling was last trading at $1.3589 after earlier hitting a day high of $1.3615 &#x2014; this 1.4 per cent advance leaves sterling up about 3 per cent against the dollar on the week week, which began with stronger than expected inflation figures. </p><p>The currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.</p><p>Although the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision &#x2014; and Mr Vlieghe&#x2019;s speech today &#x2014; is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so. </p><p>&#x201C;The possibility of a November or February hike is real, we think,&#x201D; analysts at Bank of America Merrill Lynch noted. &#x201C;That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.&#x201D;</p>\n\t\t\t<aside class=\"n-content-recommended\" role=\"complementary\" data-editorial-component-id=\"component1\">\n\t\t\t\t<h2 class=\"n-content-recommended__title\">Recommended</h2>\n\t\t\t\t\n\t\t\t\t<ul><li><a href=\"/content/de3e1832-97cc-11e7-b83c-9588e51488a0\">Will UK economy be turbocharged by sterling fall</a>?</li><li><a href=\"/content/d43c7982-97d1-11e7-b83c-9588e51488a0\">The Bank of England&#x2019;s bark is loud but it has no bite</a></li><li><a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">Bank of England&#x2019;s interest rate rhetoric divides opinion</a></li></ul>\n\t\t\t</aside>\n\t\t<p>Before Mr Vlieghe&#x2019;s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have <a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">reservations</a> about the shift from the bank.</p><p>Mr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have &#x201C;a larger impact on the economy than we have seen so far&#x201D;.</p><p>David Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was &#x201C;deliberately set to stabilise further the pound sterling&#x201D;.</p><p>The currency&#x2019;s weakness has been a strong driver of inflation and the pound&#x2019;s renewed strength &#x201C;will limit the inflation overshoot&#x201D;.</p><p>While strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained &#x201C;many doubters&#x201D; in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.</p><p>&#x201C;The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,&#x201D; said Mr Rochester.</p>",
+  "openingHTML": "<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-id=\"https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" alt=\"LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer &#xA3;10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer &#xA3;20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)\" width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Getty\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Getty\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure><p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p>",
   "url": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
   "relativeUrl": "/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+  "_editorialComponents": [
+    {
+      "componentId": "component1",
+      "componentType": "recommended-reads",
+      "stories": [
+        {
+          "image": {
+            "url": "http://prod-upp-image-read.ft.com/ad26302e-9879-11e7-8c5c-c8d8fa6961bb",
+            "width": 2048,
+            "height": 1152
+          },
+          "metaSuffixText": null,
+          "standfirst": "Economists say Britain unlikely to repeat export boom of 25 years ago after ERM exit",
+          "metaAltLink": null,
+          "relativeUrl": "/content/de3e1832-97cc-11e7-b83c-9588e51488a0",
+          "type": "article",
+          "indicators": {
+            "isColumn": false,
+            "isOpinion": false,
+            "isScoop": false,
+            "isExclusive": false,
+            "isEditorsChoice": false,
+            "accessLevel": "subscribed"
+          },
+          "title": "Will UK economy be turbocharged by sterling fall?",
+          "url": "https://www.ft.com/content/de3e1832-97cc-11e7-b83c-9588e51488a0",
+          "metaPrefixText": "Analysis",
+          "headshot": null,
+          "id": "de3e1832-97cc-11e7-b83c-9588e51488a0",
+          "publishedDate": "2017-09-13T14:36:51.000Z",
+          "firstPublishedDate": "2017-09-13T14:36:51.000Z",
+          "metaLink": {
+            "id": "19b95057-4614-45fb-9306-4d54049354db",
+            "predicate": "http://www.ft.com/ontology/annotation/about",
+            "prefLabel": "Brexit",
+            "type": "TOPIC",
+            "url": "https://www.ft.com/brexit",
+            "relativeUrl": "/brexit"
+          },
+          "parentTheme": null,
+          "altStandfirst": null
+        },
+        {
+          "image": {
+            "url": "http://prod-upp-image-read.ft.com/0501c122-995c-11e7-8c5c-c8d8fa6961bb",
+            "width": 2048,
+            "height": 1152
+          },
+          "metaSuffixText": null,
+          "standfirst": "Monetary policy has not tightened, despite policymakers’ repeated rate-rise signals",
+          "metaAltLink": {
+            "id": "d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+            "predicate": "http://www.ft.com/ontology/annotation/about",
+            "prefLabel": "UK interest rates",
+            "type": "TOPIC",
+            "url": "https://www.ft.com/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+            "relativeUrl": "/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b"
+          },
+          "relativeUrl": "/content/d43c7982-97d1-11e7-b83c-9588e51488a0",
+          "type": "article",
+          "indicators": {
+            "isColumn": true,
+            "isOpinion": true,
+            "isScoop": false,
+            "isExclusive": false,
+            "isEditorsChoice": false,
+            "accessLevel": "subscribed"
+          },
+          "title": "The Bank of England’s bark is loud but it has no bite",
+          "url": "https://www.ft.com/content/d43c7982-97d1-11e7-b83c-9588e51488a0",
+          "metaPrefixText": null,
+          "headshot": "fthead-v1:chris-giles",
+          "id": "d43c7982-97d1-11e7-b83c-9588e51488a0",
+          "publishedDate": "2017-09-14T16:54:53.000Z",
+          "firstPublishedDate": "2017-09-14T16:54:53.000Z",
+          "metaLink": {
+            "id": "1d556016-ad16-4fe7-8724-42b3fb15ad28",
+            "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+            "prefLabel": "Chris Giles",
+            "type": "PERSON",
+            "attributes": [
+              {
+                "key": "headshot",
+                "value": "fthead-v1:chris-giles"
+              }
+            ],
+            "url": "https://www.ft.com/chris-giles",
+            "relativeUrl": "/chris-giles"
+          },
+          "parentTheme": null,
+          "altStandfirst": null
+        },
+        {
+          "image": {
+            "url": "http://prod-upp-image-read.ft.com/b9d7e924-996a-11e7-8c5c-c8d8fa6961bb",
+            "width": 2048,
+            "height": 1152
+          },
+          "metaSuffixText": null,
+          "standfirst": "Economists split over whether BoE will follow through and tighten monetary policy",
+          "metaAltLink": null,
+          "relativeUrl": "/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+          "type": "article",
+          "indicators": {
+            "isColumn": false,
+            "isOpinion": false,
+            "isScoop": false,
+            "isExclusive": false,
+            "isEditorsChoice": false,
+            "accessLevel": "subscribed"
+          },
+          "title": "Bank of England’s rate rhetoric divides opinion",
+          "url": "https://www.ft.com/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+          "metaPrefixText": "Analysis",
+          "headshot": null,
+          "id": "6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+          "publishedDate": "2017-09-14T17:46:46.000Z",
+          "firstPublishedDate": "2017-09-14T17:46:46.000Z",
+          "metaLink": {
+            "id": "d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+            "predicate": "http://www.ft.com/ontology/annotation/about",
+            "prefLabel": "UK interest rates",
+            "type": "TOPIC",
+            "url": "https://www.ft.com/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+            "relativeUrl": "/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b"
+          },
+          "parentTheme": null,
+          "altStandfirst": null
+        }
+      ]
+    }
+  ],
   "annotations": [
     {
-      "apiUrl": "http://api.ft.com/things/1e0a2449-d86d-3b94-a888-9eb596f2592c",
+      "apiUrl": "http://api.ft.com/things/6b683eff-56c3-43d9-acfc-7511d974fc01",
+      "directType": "http://www.ft.com/ontology/Location",
+      "id": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+      "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
+      "prefLabel": "UK",
+      "type": "LOCATION",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/Location"
+      ],
+      "preposition": "on",
+      "url": "https://www.ft.com/world/uk",
+      "relativeUrl": "/world/uk"
+    },
+    {
+      "apiUrl": "http://api.ft.com/things/04126152-5bef-4dda-86bf-81f66c00a342",
       "directType": "http://www.ft.com/ontology/Topic",
-      "id": "1e0a2449-d86d-3b94-a888-9eb596f2592c",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Pound Sterling",
+      "id": "04126152-5bef-4dda-86bf-81f66c00a342",
+      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+      "prefLabel": "Currencies",
       "type": "TOPIC",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/Topic"
       ],
-      "url": "https://www.ft.com/topics/themes/Sterling",
       "preposition": "on",
-      "relativeUrl": "/topics/themes/Sterling"
+      "url": "https://www.ft.com/currencies",
+      "relativeUrl": "/currencies"
+    },
+    {
+      "apiUrl": "http://api.ft.com/things/c91b1fad-1097-468b-be82-9a8ff717d54c",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Markets",
+      "type": "TOPIC",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "preposition": "on",
+      "url": "https://www.ft.com/markets",
+      "relativeUrl": "/markets"
     },
     {
       "apiUrl": "http://api.ft.com/people/f7428da5-c1d2-35d7-abef-95be5f382b78",
@@ -89,31 +278,14 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/stream/f7428da5-c1d2-35d7-abef-95be5f382b78",
       "preposition": "on",
+      "url": "https://www.ft.com/stream/f7428da5-c1d2-35d7-abef-95be5f382b78",
       "relativeUrl": "/stream/f7428da5-c1d2-35d7-abef-95be5f382b78"
     },
     {
-      "apiUrl": "http://api.ft.com/things/19e0e2af-78c6-3e3d-942b-e4fbe27516dd",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "19e0e2af-78c6-3e3d-942b-e4fbe27516dd",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "Currencies",
-      "type": "SECTION",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
-      ],
-      "url": "https://www.ft.com/markets/currencies",
-      "preposition": "in",
-      "relativeUrl": "/markets/currencies"
-    },
-    {
-      "apiUrl": "http://api.ft.com/things/9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+      "apiUrl": "http://api.ft.com/things/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
       "directType": "http://www.ft.com/ontology/Genre",
-      "id": "9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+      "id": "a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
       "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
       "prefLabel": "News",
       "type": "GENRE",
@@ -123,63 +295,30 @@
         "http://www.ft.com/ontology/classification/Classification",
         "http://www.ft.com/ontology/Genre"
       ],
-      "url": "https://www.ft.com/stream/9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
       "preposition": "",
-      "relativeUrl": "/stream/9b40e89c-e87b-3d4f-b72c-2cf7511d2146"
+      "url": "https://www.ft.com/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+      "relativeUrl": "/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6"
     },
     {
-      "apiUrl": "http://api.ft.com/things/1a2a1a0a-7199-38b8-8a73-e651e2172471",
-      "directType": "http://www.ft.com/ontology/Location",
-      "id": "1a2a1a0a-7199-38b8-8a73-e651e2172471",
-      "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-      "prefLabel": "United Kingdom",
-      "type": "LOCATION",
+      "apiUrl": "http://api.ft.com/things/466a4700-307f-47cc-83f1-c5f97a172232",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+      "predicate": "http://www.ft.com/ontology/annotation/about",
+      "prefLabel": "Pound Sterling",
+      "type": "TOPIC",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
         "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/Location"
+        "http://www.ft.com/ontology/Topic"
       ],
-      "url": "https://www.ft.com/stream/1a2a1a0a-7199-38b8-8a73-e651e2172471",
       "preposition": "on",
-      "relativeUrl": "/stream/1a2a1a0a-7199-38b8-8a73-e651e2172471"
+      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
     },
     {
-      "apiUrl": "http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-95cfd0884740",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "d969d76e-f8f4-34ae-bc38-95cfd0884740",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Markets",
-      "type": "SECTION",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
-      ],
-      "url": "https://www.ft.com/markets",
-      "preposition": "in",
-      "relativeUrl": "/markets"
-    },
-    {
-      "apiUrl": "http://api.ft.com/people/18915f53-6f96-3540-9d72-2e0400075201",
+      "apiUrl": "http://api.ft.com/people/dd4b519f-e896-4322-8f77-25c936eb9d32",
       "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "18915f53-6f96-3540-9d72-2e0400075201",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Kate Allen",
-      "type": "PERSON",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/person/Person"
-      ],
-      "url": "https://www.ft.com/stream/18915f53-6f96-3540-9d72-2e0400075201",
-      "preposition": "from",
-      "relativeUrl": "/stream/18915f53-6f96-3540-9d72-2e0400075201"
-    },
-    {
-      "apiUrl": "http://api.ft.com/people/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-      "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
+      "id": "dd4b519f-e896-4322-8f77-25c936eb9d32",
       "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
       "prefLabel": "Roger Blitz",
       "type": "PERSON",
@@ -188,15 +327,115 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
       "preposition": "from",
-      "relativeUrl": "/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d"
+      "url": "https://www.ft.com/roger-blitz",
+      "relativeUrl": "/roger-blitz"
+    },
+    {
+      "apiUrl": "http://api.ft.com/people/33b4cf11-6854-4dc5-aadb-f0a671da0753",
+      "directType": "http://www.ft.com/ontology/person/Person",
+      "id": "33b4cf11-6854-4dc5-aadb-f0a671da0753",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Kate Allen",
+      "type": "PERSON",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/person/Person"
+      ],
+      "preposition": "from",
+      "attributes": [
+        {
+          "key": "headshot",
+          "value": "fthead-v1:kate-allen"
+        }
+      ],
+      "url": "https://www.ft.com/kate-allen",
+      "relativeUrl": "/kate-allen"
+    },
+    {
+      "apiUrl": "http://api.ft.com/things/049291ca-c558-4b3d-ac99-cdc2e19dfc46",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "049291ca-c558-4b3d-ac99-cdc2e19dfc46",
+      "predicate": "http://www.ft.com/ontology/implicitlyAbout",
+      "prefLabel": "Foreign exchange",
+      "type": "TOPIC",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "preposition": "on",
+      "url": "https://www.ft.com/reports/foreign-exchange",
+      "relativeUrl": "/reports/foreign-exchange"
     }
   ],
+  "genreConcept": {
+    "apiUrl": "http://api.ft.com/things/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+    "directType": "http://www.ft.com/ontology/Genre",
+    "id": "a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+    "prefLabel": "News",
+    "type": "GENRE",
+    "types": [
+      "http://www.ft.com/ontology/core/Thing",
+      "http://www.ft.com/ontology/concept/Concept",
+      "http://www.ft.com/ontology/classification/Classification",
+      "http://www.ft.com/ontology/Genre"
+    ],
+    "preposition": "",
+    "url": "https://www.ft.com/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+    "relativeUrl": "/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6"
+  },
+  "authorConcepts": [
+    {
+      "apiUrl": "http://api.ft.com/people/dd4b519f-e896-4322-8f77-25c936eb9d32",
+      "directType": "http://www.ft.com/ontology/person/Person",
+      "id": "dd4b519f-e896-4322-8f77-25c936eb9d32",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Roger Blitz",
+      "type": "PERSON",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/person/Person"
+      ],
+      "preposition": "from",
+      "url": "https://www.ft.com/roger-blitz",
+      "relativeUrl": "/roger-blitz"
+    },
+    {
+      "apiUrl": "http://api.ft.com/people/33b4cf11-6854-4dc5-aadb-f0a671da0753",
+      "directType": "http://www.ft.com/ontology/person/Person",
+      "id": "33b4cf11-6854-4dc5-aadb-f0a671da0753",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Kate Allen",
+      "type": "PERSON",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/person/Person"
+      ],
+      "preposition": "from",
+      "attributes": [
+        {
+          "key": "headshot",
+          "value": "fthead-v1:kate-allen"
+        }
+      ],
+      "url": "https://www.ft.com/kate-allen",
+      "relativeUrl": "/kate-allen"
+    }
+  ],
+  "design": {
+    "theme": "basic",
+    "layout": "default"
+  },
   "displayConcept": {
-    "apiUrl": "http://api.ft.com/things/1e0a2449-d86d-3b94-a888-9eb596f2592c",
+    "apiUrl": "http://api.ft.com/things/466a4700-307f-47cc-83f1-c5f97a172232",
     "directType": "http://www.ft.com/ontology/Topic",
-    "id": "1e0a2449-d86d-3b94-a888-9eb596f2592c",
+    "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+    "predicate": "http://www.ft.com/ontology/annotation/about",
     "prefLabel": "Pound Sterling",
     "type": "TOPIC",
     "types": [
@@ -204,43 +443,74 @@
       "http://www.ft.com/ontology/concept/Concept",
       "http://www.ft.com/ontology/Topic"
     ],
-    "url": "https://www.ft.com/topics/themes/Sterling",
     "preposition": "on",
-    "relativeUrl": "/topics/themes/Sterling"
+    "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+    "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+    "isDisplayTag": false
   },
-  "genreConcept": null,
-  "authorConcepts": [
-    {
-      "apiUrl": "http://api.ft.com/people/18915f53-6f96-3540-9d72-2e0400075201",
-      "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "18915f53-6f96-3540-9d72-2e0400075201",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Kate Allen",
-      "type": "PERSON",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/person/Person"
-      ],
-      "url": "https://www.ft.com/stream/18915f53-6f96-3540-9d72-2e0400075201",
-      "preposition": "from",
-      "relativeUrl": "/stream/18915f53-6f96-3540-9d72-2e0400075201"
+  "teaser": {
+    "id": "42ad255a-99f9-11e7-b83c-9588e51488a0",
+    "url": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+    "relativeUrl": "/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+    "type": "article",
+    "indicators": {
+      "isColumn": false,
+      "isOpinion": false,
+      "isScoop": false,
+      "isExclusive": false,
+      "isEditorsChoice": false,
+      "accessLevel": "subscribed"
     },
-    {
-      "apiUrl": "http://api.ft.com/people/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-      "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Roger Blitz",
-      "type": "PERSON",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/person/Person"
-      ],
-      "url": "https://www.ft.com/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-      "preposition": "from",
-      "relativeUrl": "/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d"
-    }
-  ]
+    "metaPrefixText": null,
+    "metaSuffixText": null,
+    "metaLink": {
+      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+      "predicate": "http://www.ft.com/ontology/annotation/about",
+      "prefLabel": "Pound Sterling",
+      "type": "TOPIC",
+      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
+    },
+    "metaAltLink": null,
+    "title": "Pound leaps to highest level since Brexit vote",
+    "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
+    "altStandfirst": null,
+    "publishedDate": "2017-09-15T15:48:53.000Z",
+    "firstPublishedDate": "2017-09-15T10:25:00.000Z",
+    "image": {
+      "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+      "width": 2048,
+      "height": 1152
+    },
+    "headshot": null,
+    "parentTheme": null
+  },
+  "contentStats": {
+    "wordCount": 555,
+    "paragraphs": 16,
+    "relatedBoxes": 0,
+    "pullQuotes": 0,
+    "pullQuotesWithImages": 0,
+    "bigNumbers": 0,
+    "images": 2,
+    "responsiveImages": 0,
+    "graphics": 1,
+    "audio": 0,
+    "videos": 0,
+    "internalVideos": 0,
+    "externalVideos": 0,
+    "subheadings": 0,
+    "curatedRecommended": 1,
+    "layouts": 0,
+    "layoutSlots": 0,
+    "infoBox": 0,
+    "tables": 0,
+    "timelines": 0,
+    "singleArticleRecommendations": 0,
+    "sentiment": 1,
+    "scoreGraphicVolume": 1,
+    "scoreGraphicDensity": 0.001802,
+    "scorePictureVolume": 1,
+    "scorePictureDensity": 0.001802
+  }
 }

--- a/test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json
+++ b/test/fixtures/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2.json
@@ -1,42 +1,38 @@
 {
   "id": "a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
-  "webUrl": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+  "webUrl": "https://www.ft.com/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
   "title": "Is being authentic enough to be a leader?",
+  "alternativeTitles": {},
+  "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
   "provenance": [
-    "http://api.ft.com/internalcontent/a1af0574-eafb-41bd-aa4f-59aa2cd084c2"
+    "https://api.ft.com/internalcontent/a1af0574-eafb-41bd-aa4f-59aa2cd084c2"
   ],
   "byline": "Produced by Alessia Giustiniano. Filmed by Rod Fitzgerald.",
-  "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
   "publishedDate": "2017-09-13T17:10:52.586Z",
   "firstPublishedDate": "2017-09-13T17:10:52.586Z",
   "publishReference": "tid_updlmq8ym2",
   "curatedRelatedContent": [
     {
-      "apiUrl": "http://api.ft.com/content/996fbb84-96d7-11e7-b83c-9588e51488a0",
-      "id": "996fbb84-96d7-11e7-b83c-9588e51488a0"
+      "id": "996fbb84-96d7-11e7-b83c-9588e51488a0",
+      "apiUrl": "http://api.ft.com/content/996fbb84-96d7-11e7-b83c-9588e51488a0"
     }
   ],
+  "containedIn": [],
+  "canBeDistributed": "yes",
   "canBeSyndicated": "yes",
   "comments": {
     "enabled": false
   },
-  "standout": { },
+  "standout": {},
   "realtime": false,
   "originatingParty": "FT",
-  "_lastUpdatedDateTime": "2017-09-13T17:37:35.924Z",
+  "_lastUpdatedDateTime": "2020-09-02T03:05:43.205Z",
+  "_lastUpdatedVersion": "a96145043202ee9d2483edd57d2de1b23e695e7a",
   "type": "video",
   "description": "The FT's editor Lionel Barber and Janan Ganesh, our chief political commentator, discuss the recent political party candidates and examine whether being authentic is sufficient to be an effective leader.",
   "bodyHTML": "<p>The British political season is almost upon us. And many people are asking, might Theresa May face a leadership challenge. And what about the leadership qualities of Jeremy Corbyn newly rejuvenated? What is the ultimate test of leadership? Is it authenticity? Here with me to discuss this is Janan Ganesh and you made a quite extraordinary attack this week on authenticity and a putative challenger to Mrs. May, Jacob Rees-Mogg. </p><p>Yeah, authenticity has become the gold dust when looking for political candidates in the modern world. Jeremy Corbyn is seen to have done well as labour leader because he has authenticity. Boris Johnson for a long time looked like a plausible prime minister because people said, well, he's authentic. He's unspun. But I think him Jacob Rees-Mogg you have an example of someone who's clearly authentic, doesn't disguise the fact that he's a very privileged man, and doesn't disguise the fact that he's-- </p><p>Some of the times editor. </p><p>Former newspaper editor. </p><p>William Rees-Mogg. </p><p>But doesn't also disguise the fact that he's a committed Catholic. And he expressed views on abortion and same-sex marriage that annoyed a lot of people who were big fans of him only two weeks ago. And that's an example of the fact that when people say they want authenticity, what they mean is the kind of authenticity they like. </p><p>Yeah but-- </p><p>There's good authenticity and then there's the bad stuff, which they suddenly go cold over. </p><p>Yeah, but Janan, I mean, we watched the British election campaign earlier this year in which Theresa May, for all her qualities, was incapable of spontaneous talking, speaking on the trail. And she wasn't authentic. </p><p>She could argue that that was the authentic her, that she's not a natural public performer. She's not a natural people person. Actually she's a diligent, behind-the-scenes kind of politician who works through a brief and does her best in that way, rather than a spectacular personality. But that's fine. The problem I have with the authenticity cult is that people think it's somehow enough. That if someone is expressive of views that are unusual, doesn't employ a media adviser, it's very direct-- </p><p>That's the point about media advisers. I mean, you know, I've covered American presidential campaigns. I mean, they're all over the place. You get the blow dried hair cut candidate. </p><p>Yeah. </p><p>And he's totally scripted or she's totally scripted. Look at Hillary Clinton last year. </p><p>And that's annoying to a lot of people and hard to connect with. But in office, is it enough to say, well, I'm authentic and, therefore, I should be national leader of a country of 60 million people with nuclear weapons and a very large economy. I think authenticity is not even necessary, let alone sufficient. And we started to talk about it as though it was almost a sufficient criterion on which to elect a national leader. </p><p>Well, I'm coming round to your point of view. But what about Jeremy Corbyn? I mean, isn't he authentic? I mean, the flat cap, the beard has been trimmed now, of course. </p><p>A bit, yeah. </p><p>But you know, he is what he looks like, which is a 1970s style socialist. </p><p>Completely, I think he's entirely authentic. Hasn't changed his views since he entered parliament in the early 1980s, completely unspun, slight trimming of the beard. I think he started to wear a suit now, or at least a jacket and tie but nothing artificial really. But is that a sufficient criterion on which to elect a national leader? And my only-- </p><p>So what are the qualities that we need? And if we're going to put authenticity slightly to the side, not completely-- </p><p>Yeah. </p><p>What are we looking at? </p><p>I think that-- I still think a good national leader will, to a large extent, be inauthentic. And we will find them objectionable in many ways. And so someone like a Tony Blair or a John Major was seen to be sometimes underhand to not say the entirety of what they mean. And that's necessary. You're having to balance interests within your cabinet. You're having to balance principle with practical reality. You're having to set this interest group up against that one and somehow keep some semblance of popularity while governing the country. </p><p>You can only do that as a national leader if you are a little bit sly, a little bit inauthentic, and are willing to not say absolutely everything you mean at any given time. So I think it's almost kind of weirdly juvenile demand that we, as the media, and to a certain extent the electorate have come up with in expecting everyone to be completely honest and authentic all the time. </p><p>So I'm writing down Jacob Rees-Mogg's chances of being the next Conservative Party leader. Thank you Janan Ganesh. </p><p>Thank you. </p>",
+  "bodyText": "The British political season is almost upon us. And many people are asking, might Theresa May face a leadership challenge. And what about the leadership qualities of Jeremy Corbyn newly rejuvenated? What is the ultimate test of leadership? Is it authenticity? Here with me to discuss this is Janan Ganesh and you made a quite extraordinary attack this week on authenticity and a putative challenger to Mrs. May, Jacob Rees-Mogg.\n\nYeah, authenticity has become the gold dust when looking for political candidates in the modern world. Jeremy Corbyn is seen to have done well as labour leader because he has authenticity. Boris Johnson for a long time looked like a plausible prime minister because people said, well, he's authentic. He's unspun. But I think him Jacob Rees-Mogg you have an example of someone who's clearly authentic, doesn't disguise the fact that he's a very privileged man, and doesn't disguise the fact that he's--\n\nSome of the times editor.\n\nFormer newspaper editor.\n\nWilliam Rees-Mogg.\n\nBut doesn't also disguise the fact that he's a committed Catholic. And he expressed views on abortion and same-sex marriage that annoyed a lot of people who were big fans of him only two weeks ago. And that's an example of the fact that when people say they want authenticity, what they mean is the kind of authenticity they like.\n\nYeah but--\n\nThere's good authenticity and then there's the bad stuff, which they suddenly go cold over.\n\nYeah, but Janan, I mean, we watched the British election campaign earlier this year in which Theresa May, for all her qualities, was incapable of spontaneous talking, speaking on the trail. And she wasn't authentic.\n\nShe could argue that that was the authentic her, that she's not a natural public performer. She's not a natural people person. Actually she's a diligent, behind-the-scenes kind of politician who works through a brief and does her best in that way, rather than a spectacular personality. But that's fine. The problem I have with the authenticity cult is that people think it's somehow enough. That if someone is expressive of views that are unusual, doesn't employ a media adviser, it's very direct--\n\nThat's the point about media advisers. I mean, you know, I've covered American presidential campaigns. I mean, they're all over the place. You get the blow dried hair cut candidate.\n\nYeah.\n\nAnd he's totally scripted or she's totally scripted. Look at Hillary Clinton last year.\n\nAnd that's annoying to a lot of people and hard to connect with. But in office, is it enough to say, well, I'm authentic and, therefore, I should be national leader of a country of 60 million people with nuclear weapons and a very large economy. I think authenticity is not even necessary, let alone sufficient. And we started to talk about it as though it was almost a sufficient criterion on which to elect a national leader.\n\nWell, I'm coming round to your point of view. But what about Jeremy Corbyn? I mean, isn't he authentic? I mean, the flat cap, the beard has been trimmed now, of course.\n\nA bit, yeah.\n\nBut you know, he is what he looks like, which is a 1970s style socialist.\n\nCompletely, I think he's entirely authentic. Hasn't changed his views since he entered parliament in the early 1980s, completely unspun, slight trimming of the beard. I think he started to wear a suit now, or at least a jacket and tie but nothing artificial really. But is that a sufficient criterion on which to elect a national leader? And my only--\n\nSo what are the qualities that we need? And if we're going to put authenticity slightly to the side, not completely--\n\nYeah.\n\nWhat are we looking at?\n\nI think that-- I still think a good national leader will, to a large extent, be inauthentic. And we will find them objectionable in many ways. And so someone like a Tony Blair or a John Major was seen to be sometimes underhand to not say the entirety of what they mean. And that's necessary. You're having to balance interests within your cabinet. You're having to balance principle with practical reality. You're having to set this interest group up against that one and somehow keep some semblance of popularity while governing the country.\n\nYou can only do that as a national leader if you are a little bit sly, a little bit inauthentic, and are willing to not say absolutely everything you mean at any given time. So I think it's almost kind of weirdly juvenile demand that we, as the media, and to a certain extent the electorate have come up with in expecting everyone to be completely honest and authentic all the time.\n\nSo I'm writing down Jacob Rees-Mogg's chances of being the next Conservative Party leader. Thank you Janan Ganesh.\n\nThank you.",
   "url": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
-  "mainImage": {
-    "title": "VIDEO_MAS-OPINION_ReesMogg_LionelJanan.jpg",
-    "description": "",
-    "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
-    "width": 2048,
-    "height": 1152,
-    "ratio": 1.7777777777777777,
-    "aspectRatio": 0.5625
-  },
   "attachments": [
     {
       "url": "https://next-media-api.ft.com/renditions/15053217972320/640x360.mp4",
@@ -67,43 +63,17 @@
       "url": "https://next-media-api.ft.com/captions/15053217972320.vtt"
     }
   ],
-  "containedIn": [ ],
   "relativeUrl": "/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+  "mainImage": {
+    "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
+    "title": "VIDEO_MAS-OPINION_ReesMogg_LionelJanan.jpg",
+    "description": "",
+    "width": 2048,
+    "height": 1152,
+    "ratio": 1.77778,
+    "aspectRatio": 0.5625
+  },
   "annotations": [
-    {
-      "apiUrl": "http://api.ft.com/things/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "directType": "http://www.ft.com/ontology/Genre",
-      "id": "e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Comment",
-      "type": "GENRE",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Genre"
-      ],
-      "url": "https://www.ft.com/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "preposition": "",
-      "relativeUrl": "/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05"
-    },
-    {
-      "apiUrl": "http://api.ft.com/things/38dbd827-fedc-3ebe-919f-e64cf55ea959",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "38dbd827-fedc-3ebe-919f-e64cf55ea959",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Opinion",
-      "type": "SECTION",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
-      ],
-      "url": "https://www.ft.com/opinion",
-      "preposition": "in",
-      "relativeUrl": "/opinion"
-    },
     {
       "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
       "directType": "http://www.ft.com/ontology/product/Brand",
@@ -117,36 +87,31 @@
         "http://www.ft.com/ontology/classification/Classification",
         "http://www.ft.com/ontology/product/Brand"
       ],
-      "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
       "preposition": "from",
+      "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
       "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
     },
     {
-      "apiUrl": "http://api.ft.com/people/a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-      "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Janan Ganesh",
-      "type": "PERSON",
+      "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+      "directType": "http://www.ft.com/ontology/Genre",
+      "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Opinion",
+      "type": "GENRE",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
         "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/person/Person"
+        "http://www.ft.com/ontology/classification/Classification",
+        "http://www.ft.com/ontology/Genre"
       ],
-      "url": "https://www.ft.com/comment/columnists/janan-ganesh",
-      "preposition": "from",
-      "relativeUrl": "/comment/columnists/janan-ganesh",
-      "attributes": [
-        {
-          "key": "headshot",
-          "value": "fthead:janan-ganesh"
-        }
-      ]
+      "preposition": "",
+      "url": "https://www.ft.com/opinion",
+      "relativeUrl": "/opinion"
     },
     {
-      "apiUrl": "http://api.ft.com/people/7fce0429-54de-31d5-b511-acc9c4914eb2",
+      "apiUrl": "http://api.ft.com/people/08c3aeaf-259b-436a-83d9-7253c78540fc",
       "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "7fce0429-54de-31d5-b511-acc9c4914eb2",
+      "id": "08c3aeaf-259b-436a-83d9-7253c78540fc",
       "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
       "prefLabel": "Lionel Barber",
       "type": "PERSON",
@@ -155,34 +120,56 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/lionel-barber",
       "preposition": "from",
-      "relativeUrl": "/lionel-barber",
       "attributes": [
         {
           "key": "headshot",
-          "value": "fthead:lionel-barber"
+          "value": "fthead-v1:lionel-barber"
         }
-      ]
+      ],
+      "url": "https://www.ft.com/lionel-barber",
+      "relativeUrl": "/lionel-barber"
+    },
+    {
+      "apiUrl": "http://api.ft.com/people/b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+      "directType": "http://www.ft.com/ontology/person/Person",
+      "id": "b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Janan Ganesh",
+      "type": "PERSON",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/person/Person"
+      ],
+      "preposition": "from",
+      "attributes": [
+        {
+          "key": "headshot",
+          "value": "fthead-v1:janan-ganesh"
+        }
+      ],
+      "url": "https://www.ft.com/janan-ganesh",
+      "relativeUrl": "/janan-ganesh"
     }
   ],
-  "displayConcept": {
-    "apiUrl": "http://api.ft.com/things/38dbd827-fedc-3ebe-919f-e64cf55ea959",
-    "directType": "http://www.ft.com/ontology/Section",
-    "id": "38dbd827-fedc-3ebe-919f-e64cf55ea959",
+  "genreConcept": {
+    "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+    "directType": "http://www.ft.com/ontology/Genre",
+    "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
     "prefLabel": "Opinion",
-    "type": "SECTION",
+    "type": "GENRE",
     "types": [
       "http://www.ft.com/ontology/core/Thing",
       "http://www.ft.com/ontology/concept/Concept",
       "http://www.ft.com/ontology/classification/Classification",
-      "http://www.ft.com/ontology/Section"
+      "http://www.ft.com/ontology/Genre"
     ],
+    "preposition": "",
     "url": "https://www.ft.com/opinion",
-    "preposition": "in",
     "relativeUrl": "/opinion"
   },
-  "genreConcept": null,
   "brandConcept": {
     "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
     "directType": "http://www.ft.com/ontology/product/Brand",
@@ -196,37 +183,15 @@
       "http://www.ft.com/ontology/classification/Classification",
       "http://www.ft.com/ontology/product/Brand"
     ],
-    "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
     "preposition": "from",
+    "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
     "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
   },
   "authorConcepts": [
     {
-      "apiUrl": "http://api.ft.com/people/a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
+      "apiUrl": "http://api.ft.com/people/08c3aeaf-259b-436a-83d9-7253c78540fc",
       "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Janan Ganesh",
-      "type": "PERSON",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/person/Person"
-      ],
-      "url": "https://www.ft.com/comment/columnists/janan-ganesh",
-      "preposition": "from",
-      "relativeUrl": "/comment/columnists/janan-ganesh",
-      "attributes": [
-        {
-          "key": "headshot",
-          "value": "fthead:janan-ganesh"
-        }
-      ]
-    },
-    {
-      "apiUrl": "http://api.ft.com/people/7fce0429-54de-31d5-b511-acc9c4914eb2",
-      "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "7fce0429-54de-31d5-b511-acc9c4914eb2",
+      "id": "08c3aeaf-259b-436a-83d9-7253c78540fc",
       "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
       "prefLabel": "Lionel Barber",
       "type": "PERSON",
@@ -235,15 +200,102 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/lionel-barber",
       "preposition": "from",
-      "relativeUrl": "/lionel-barber",
       "attributes": [
         {
           "key": "headshot",
-          "value": "fthead:lionel-barber"
+          "value": "fthead-v1:lionel-barber"
         }
-      ]
+      ],
+      "url": "https://www.ft.com/lionel-barber",
+      "relativeUrl": "/lionel-barber"
+    },
+    {
+      "apiUrl": "http://api.ft.com/people/b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+      "directType": "http://www.ft.com/ontology/person/Person",
+      "id": "b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Janan Ganesh",
+      "type": "PERSON",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/person/Person"
+      ],
+      "preposition": "from",
+      "attributes": [
+        {
+          "key": "headshot",
+          "value": "fthead-v1:janan-ganesh"
+        }
+      ],
+      "url": "https://www.ft.com/janan-ganesh",
+      "relativeUrl": "/janan-ganesh"
     }
-  ]
+  ],
+  "design": {
+    "theme": "basic",
+    "layout": "default"
+  },
+  "displayConcept": {
+    "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+    "directType": "http://www.ft.com/ontology/product/Brand",
+    "id": "6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+    "prefLabel": "FT World video",
+    "type": "BRAND",
+    "types": [
+      "http://www.ft.com/ontology/core/Thing",
+      "http://www.ft.com/ontology/concept/Concept",
+      "http://www.ft.com/ontology/classification/Classification",
+      "http://www.ft.com/ontology/product/Brand"
+    ],
+    "preposition": "from",
+    "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+    "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+    "isDisplayTag": false
+  },
+  "teaser": {
+    "id": "a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+    "url": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+    "relativeUrl": "/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+    "type": "video",
+    "indicators": {
+      "isColumn": false,
+      "isOpinion": true,
+      "isScoop": false,
+      "isExclusive": false,
+      "isEditorsChoice": false,
+      "accessLevel": "subscribed"
+    },
+    "metaPrefixText": "FT World video",
+    "metaSuffixText": "5 min",
+    "metaLink": {
+      "id": "6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "FT World video",
+      "type": "BRAND",
+      "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+      "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
+    },
+    "metaAltLink": null,
+    "title": "Is being authentic enough to be a leader?",
+    "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
+    "altStandfirst": null,
+    "publishedDate": "2017-09-13T17:10:52.586Z",
+    "firstPublishedDate": "2017-09-13T17:10:52.586Z",
+    "image": {
+      "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
+      "width": 2048,
+      "height": 1152
+    },
+    "video": {
+      "url": "https://next-media-api.ft.com/renditions/15053217972320/640x360.mp4",
+      "width": 640,
+      "height": 360,
+      "duration": 281513,
+      "codec": "h264",
+      "mediaType": "video/mp4"
+    }
+  }
 }

--- a/test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json
+++ b/test/fixtures/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af.json
@@ -1,54 +1,50 @@
 {
   "id": "b16fce7e-3c92-48a3-ace0-d1af3fce71af",
-  "webUrl": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+  "webUrl": "https://www.ft.com/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
   "title": "Mental health and the gig economy",
+  "alternativeTitles": {},
+  "standfirst": "Flexibility is good for workers, but can bring health problems",
   "provenance": [
-    "http://api.ft.com/internalcontent/b16fce7e-3c92-48a3-ace0-d1af3fce71af"
+    "https://api.ft.com/internalcontent/b16fce7e-3c92-48a3-ace0-d1af3fce71af"
   ],
   "byline": "Graphics by Aslan Livingstone-Ra. Produced by Seb Morton-Clark and Emma Boyde.",
-  "standfirst": "Flexibility is good for workers, but can bring health problems",
   "publishedDate": "2017-09-13T12:15:43.662Z",
   "firstPublishedDate": "2017-09-13T12:15:43.662Z",
   "publishReference": "tid_eg4yqbdeuh",
   "curatedRelatedContent": [
     {
-      "apiUrl": "http://api.ft.com/content/749cb87e-6ca8-11e7-b9c7-15af748b60d0",
-      "id": "749cb87e-6ca8-11e7-b9c7-15af748b60d0"
+      "id": "749cb87e-6ca8-11e7-b9c7-15af748b60d0",
+      "apiUrl": "http://api.ft.com/content/749cb87e-6ca8-11e7-b9c7-15af748b60d0"
     },
     {
-      "apiUrl": "http://api.ft.com/content/dddf09c6-77a8-11e7-a3e8-60495fe6ca71",
-      "id": "dddf09c6-77a8-11e7-a3e8-60495fe6ca71"
+      "id": "dddf09c6-77a8-11e7-a3e8-60495fe6ca71",
+      "apiUrl": "http://api.ft.com/content/dddf09c6-77a8-11e7-a3e8-60495fe6ca71"
     },
     {
-      "apiUrl": "http://api.ft.com/content/d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa",
-      "id": "d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa"
+      "id": "d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa",
+      "apiUrl": "http://api.ft.com/content/d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa"
     },
     {
-      "apiUrl": "http://api.ft.com/content/398df8c0-67b1-11e7-8526-7b38dcaef614",
-      "id": "398df8c0-67b1-11e7-8526-7b38dcaef614"
+      "id": "398df8c0-67b1-11e7-8526-7b38dcaef614",
+      "apiUrl": "http://api.ft.com/content/398df8c0-67b1-11e7-8526-7b38dcaef614"
     }
   ],
+  "containedIn": [],
+  "canBeDistributed": "yes",
   "canBeSyndicated": "yes",
   "comments": {
     "enabled": false
   },
-  "standout": { },
+  "standout": {},
   "realtime": false,
   "originatingParty": "FT",
-  "_lastUpdatedDateTime": "2017-09-13T13:16:07.651Z",
+  "_lastUpdatedDateTime": "2020-09-02T22:31:44.236Z",
+  "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
   "type": "video",
   "description": "Workers appreciate the flexibility of the gig economy, but isolation, long hours and performance assessment by an algorithm are contributing to mental health problems",
   "bodyHTML": "<p>[MUSIC PLAYING] </p><p>Everyone is talking about the gig economy. But what exactly are they talking about? Is it big or small, exciting or terrifying? Good for you health or bad for it? </p><p>The first thing to know about the gig economy is that not everyone actually agrees on what it means. As the name suggests, it's about people who earn money from doing a series of gigs or tasks. But some people use that term to apply to everyone who works independently, including lawyers and plumbers, but, of course, the notion of working for yourself is nothing new. </p><p>What is new is the invention of digital platforms that connect customers with workers to perform tasks on demand. That task could be to do someone's ironing, translate a document from Arabic to English, deliver a pizza, or drive someone home from a nightclub. There are a host of gig economy platforms, from Upwork or HourlyNerd, for tasks that are done online, to Uber and Deliveroo, for tasks that are done in person. </p><p>The uniting feature is that they match workers to customers, and they use their technology to facilitate the payment, while taking a cut for themselves. They say they're intermediaries, not employers. Others disagree. That's a question being thrashed out in courts in the US, the UK, and elsewhere. </p><p>If you live in a city teeming with Ubers, you might think the gig economy is huge already, but, actually, the number working in it is still pretty small, but it is significant. In the UK, one think tank says about 3 and 1/2% of the workforce are in the gig economy. That's about the same number as work for the National Health Service, the UK'S largest employer. </p><p>This is a growing army of workers without work places, colleagues, or bosses. What does that mean for their health and safety? </p><p>In some ways, it could be positive. The gig economy is based on the idea of working whenever you want. Having a job where you can easily nip out to deal with something personal, studies show that's one of the best indicators for high well-being. </p><p>But some health experts are worried. Flexibility might be good for your health, but loneliness and isolation are bad for it. </p><p>Gig workers don't have line managers to keep an eye out for them. Instead, their regular contact is with an algorithm that doesn't know how they're feeling today, or what personal problems might have cropped up. The algorithm just sends them tasks and monitors their performance. </p><p>Some algorithms also deactivate workers from their platforms, if there are performance issues. That can create pressure. And when the platform sets the fee per task, some workers feel they can only increase their earnings by working ever longer hours. </p><p>Driving or cycling and traffic can be dangerous at the best of times, let alone when you're tired and stressed. </p><p>For health experts, one thing is clear, there's an urgent need to investigate the benefits and the risks of this new world of work. </p><p>[MUSIC PLAYING] </p>",
+  "bodyText": "[MUSIC PLAYING]\n\nEveryone is talking about the gig economy. But what exactly are they talking about? Is it big or small, exciting or terrifying? Good for you health or bad for it?\n\nThe first thing to know about the gig economy is that not everyone actually agrees on what it means. As the name suggests, it's about people who earn money from doing a series of gigs or tasks. But some people use that term to apply to everyone who works independently, including lawyers and plumbers, but, of course, the notion of working for yourself is nothing new.\n\nWhat is new is the invention of digital platforms that connect customers with workers to perform tasks on demand. That task could be to do someone's ironing, translate a document from Arabic to English, deliver a pizza, or drive someone home from a nightclub. There are a host of gig economy platforms, from Upwork or HourlyNerd, for tasks that are done online, to Uber and Deliveroo, for tasks that are done in person.\n\nThe uniting feature is that they match workers to customers, and they use their technology to facilitate the payment, while taking a cut for themselves. They say they're intermediaries, not employers. Others disagree. That's a question being thrashed out in courts in the US, the UK, and elsewhere.\n\nIf you live in a city teeming with Ubers, you might think the gig economy is huge already, but, actually, the number working in it is still pretty small, but it is significant. In the UK, one think tank says about 3 and 1/2% of the workforce are in the gig economy. That's about the same number as work for the National Health Service, the UK'S largest employer.\n\nThis is a growing army of workers without work places, colleagues, or bosses. What does that mean for their health and safety?\n\nIn some ways, it could be positive. The gig economy is based on the idea of working whenever you want. Having a job where you can easily nip out to deal with something personal, studies show that's one of the best indicators for high well-being.\n\nBut some health experts are worried. Flexibility might be good for your health, but loneliness and isolation are bad for it.\n\nGig workers don't have line managers to keep an eye out for them. Instead, their regular contact is with an algorithm that doesn't know how they're feeling today, or what personal problems might have cropped up. The algorithm just sends them tasks and monitors their performance.\n\nSome algorithms also deactivate workers from their platforms, if there are performance issues. That can create pressure. And when the platform sets the fee per task, some workers feel they can only increase their earnings by working ever longer hours.\n\nDriving or cycling and traffic can be dangerous at the best of times, let alone when you're tired and stressed.\n\nFor health experts, one thing is clear, there's an urgent need to investigate the benefits and the risks of this new world of work.\n\n[MUSIC PLAYING]",
   "url": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
-  "mainImage": {
-    "title": "mas-gig.png",
-    "description": "",
-    "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
-    "width": 2048,
-    "height": 1152,
-    "ratio": 1.7777777777777777,
-    "aspectRatio": 0.5625
-  },
   "attachments": [
     {
       "url": "https://next-media-api.ft.com/renditions/15053038942430/640x360.mp4",
@@ -79,30 +75,21 @@
       "url": "https://next-media-api.ft.com/captions/15053038942430.vtt"
     }
   ],
-  "containedIn": [ ],
   "relativeUrl": "/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+  "mainImage": {
+    "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
+    "title": "mas-gig.png",
+    "description": "",
+    "width": 2048,
+    "height": 1152,
+    "ratio": 1.77778,
+    "aspectRatio": 0.5625
+  },
   "annotations": [
     {
-      "apiUrl": "http://api.ft.com/things/852939c8-859c-361e-8514-f82f6c041580",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "852939c8-859c-361e-8514-f82f6c041580",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Companies",
-      "type": "SECTION",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
-      ],
-      "url": "https://www.ft.com/companies",
-      "preposition": "in",
-      "relativeUrl": "/companies"
-    },
-    {
-      "apiUrl": "http://api.ft.com/things/b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
+      "apiUrl": "http://api.ft.com/things/596c35ec-bdb3-409a-83fb-717ecd3dc029",
       "directType": "http://www.ft.com/ontology/Genre",
-      "id": "b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
+      "id": "596c35ec-bdb3-409a-83fb-717ecd3dc029",
       "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
       "prefLabel": "Explainer",
       "type": "GENRE",
@@ -112,27 +99,107 @@
         "http://www.ft.com/ontology/classification/Classification",
         "http://www.ft.com/ontology/Genre"
       ],
-      "url": "https://www.ft.com/stream/b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
       "preposition": "",
-      "relativeUrl": "/stream/b2fa15d1-56b4-3767-8bcd-595b23a5ff22"
+      "url": "https://www.ft.com/explainer",
+      "relativeUrl": "/explainer"
+    },
+    {
+      "apiUrl": "http://api.ft.com/things/c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Companies",
+      "type": "TOPIC",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "preposition": "on",
+      "url": "https://www.ft.com/companies",
+      "relativeUrl": "/companies"
     }
   ],
-  "displayConcept": {
-    "apiUrl": "http://api.ft.com/things/852939c8-859c-361e-8514-f82f6c041580",
-    "directType": "http://www.ft.com/ontology/Section",
-    "id": "852939c8-859c-361e-8514-f82f6c041580",
-    "prefLabel": "Companies",
-    "type": "SECTION",
+  "genreConcept": {
+    "apiUrl": "http://api.ft.com/things/596c35ec-bdb3-409a-83fb-717ecd3dc029",
+    "directType": "http://www.ft.com/ontology/Genre",
+    "id": "596c35ec-bdb3-409a-83fb-717ecd3dc029",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+    "prefLabel": "Explainer",
+    "type": "GENRE",
     "types": [
       "http://www.ft.com/ontology/core/Thing",
       "http://www.ft.com/ontology/concept/Concept",
       "http://www.ft.com/ontology/classification/Classification",
-      "http://www.ft.com/ontology/Section"
+      "http://www.ft.com/ontology/Genre"
     ],
-    "url": "https://www.ft.com/companies",
-    "preposition": "in",
-    "relativeUrl": "/companies"
+    "preposition": "",
+    "url": "https://www.ft.com/explainer",
+    "relativeUrl": "/explainer"
   },
-  "genreConcept": null,
-  "authorConcepts": [ ]
+  "authorConcepts": [],
+  "design": {
+    "theme": "basic",
+    "layout": "default"
+  },
+  "displayConcept": {
+    "apiUrl": "http://api.ft.com/things/c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+    "directType": "http://www.ft.com/ontology/Topic",
+    "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+    "prefLabel": "Companies",
+    "type": "TOPIC",
+    "types": [
+      "http://www.ft.com/ontology/core/Thing",
+      "http://www.ft.com/ontology/concept/Concept",
+      "http://www.ft.com/ontology/Topic"
+    ],
+    "preposition": "on",
+    "url": "https://www.ft.com/companies",
+    "relativeUrl": "/companies",
+    "isDisplayTag": false
+  },
+  "teaser": {
+    "id": "b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+    "url": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+    "relativeUrl": "/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+    "type": "video",
+    "indicators": {
+      "isColumn": false,
+      "isOpinion": false,
+      "isScoop": false,
+      "isExclusive": false,
+      "isEditorsChoice": false,
+      "accessLevel": "subscribed"
+    },
+    "metaPrefixText": "Explainer",
+    "metaSuffixText": "3 min",
+    "metaLink": {
+      "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Companies",
+      "type": "TOPIC",
+      "url": "https://www.ft.com/companies",
+      "relativeUrl": "/companies"
+    },
+    "metaAltLink": null,
+    "title": "Mental health and the gig economy",
+    "standfirst": "Flexibility is good for workers, but can bring health problems",
+    "altStandfirst": null,
+    "publishedDate": "2017-09-13T12:15:43.662Z",
+    "firstPublishedDate": "2017-09-13T12:15:43.662Z",
+    "image": {
+      "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
+      "width": 2048,
+      "height": 1152
+    },
+    "video": {
+      "url": "https://next-media-api.ft.com/renditions/15053038942430/640x360.mp4",
+      "width": 640,
+      "height": 360,
+      "duration": 178943,
+      "codec": "h264",
+      "mediaType": "video/mp4"
+    }
+  }
 }

--- a/test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json
+++ b/test/fixtures/content/ef4c49fe-980e-11e7-b83c-9588e51488a0.json
@@ -1,19 +1,22 @@
 {
   "id": "ef4c49fe-980e-11e7-b83c-9588e51488a0",
-  "webUrl": "http://www.ft.com/cms/s/ef4c49fe-980e-11e7-b83c-9588e51488a0.html",
+  "webUrl": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
   "title": "Tech companies in the city: the backlash",
   "alternativeTitles": {
     "promotionalTitle": "Tech companies in the city: the backlash"
   },
+  "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
   "provenance": [
-    "http://api.ft.com/internalcontent/ef4c49fe-980e-11e7-b83c-9588e51488a0"
+    "https://api.ft.com/internalcontent/ef4c49fe-980e-11e7-b83c-9588e51488a0"
   ],
   "byline": "Leslie Hook",
-  "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
   "publishedDate": "2017-09-15T04:01:25.000Z",
   "firstPublishedDate": "2017-09-15T04:01:25.000Z",
-  "publishReference": "tid_oyutrewelx",
-  "curatedRelatedContent": [ ],
+  "publishReference": "SYNTHETIC-REQ-MONtid_Nc4lS23YUV_carousel_1534772628",
+  "bodyText": "Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle — many locals love nothing more than a good gripe against Google or Uber or Amazon.\n\nIt’s been curious, then, to watch cities rush forward after Amazon said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company’s favour.\n\nThe prize is certainly vast — Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.\n\nIn Seattle, Amazon’s hometown, however, the company’s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon’s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.\n\nAs the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby — one in five walks to work — heightening the sense that downtown Seattle has become a company town.\n\nSuddenly Seattle’s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington’s low taxes were a key reason why Jeff Bezos set up shop there all those years ago.)\n\nAmazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big “Amazon” signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres — although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.\n\nA similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged protests at the bus stops where Google’s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.\n\nThe dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.\n\nWhile big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design tech-utopian cities of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.\n\nThe concept of a “city in a box” is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.\n\nLeslie Hook is the FT’s San Francisco correspondent\n\nIllustration by Christopher de Lorenzo",
+  "curatedRelatedContent": [],
+  "containedIn": [],
+  "canBeDistributed": "yes",
   "canBeSyndicated": "yes",
   "comments": {
     "enabled": true
@@ -24,84 +27,57 @@
     "scoop": false
   },
   "realtime": false,
+  "editorialDesk": "/FT/Weekend/The Magazine",
   "originatingParty": "FT",
-  "_lastUpdatedDateTime": "2017-09-15T07:03:59.228Z",
+  "_lastUpdatedDateTime": "2020-09-03T09:22:46.137Z",
+  "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
   "type": "article",
   "accessLevel": "subscribed",
-  "topper": { },
-  "leadImages": [ ],
-  "containedIn": [ ],
+  "topper": {},
   "mainImage": {
+    "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
     "title": "",
     "description": "",
-    "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+    "copyright": "© Christopher de Lorenzo",
     "width": 2048,
     "height": 1152,
-    "ratio": 1.7777777777777777,
+    "ratio": 1.77778,
     "aspectRatio": 0.5625
   },
-  "bodyHTML": "<figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" alt=\"\" role=\"presentation\" width=\"2048\" height=\"1152\" data-copyright=\"© Christopher de Lorenzo\"><figcaption class=\"n-content-image__caption\">© Christopher de Lorenzo</figcaption></figure><p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle — many locals love nothing more than a good gripe against Google or Uber or Amazon.</p><p>It’s been curious, then, to watch <a href=\"/content/eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0\">cities rush forward after Amazon</a> said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company’s favour.</p><p>The prize is certainly vast — Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.</p><p>In Seattle, Amazon’s hometown, however, the company’s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon’s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.</p><p>As the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby — one in five walks to work — heightening the sense that downtown Seattle has become a company town.</p><p>Suddenly Seattle’s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington’s low taxes were a key reason why <a href=\"https://www.ft.com/topics/people/Jeff_Bezos\">Jeff Bezos</a> set up shop there all those years ago.)</p><p>Amazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big “Amazon” signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres — although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.</p><p>A similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged <a href=\"https://www.wired.com/2016/02/sfs-tech-bus-problem-isnt-about-buses-its-about-housing/\">protests</a> at the bus stops where Google’s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.</p><p>The dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.</p><p>While big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design <a href=\"http://uk.businessinsider.com/silicon-valley-is-building-utopian-cities-2016-6?r=US&amp;IR=T\">tech-utopian cities</a> of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.</p><p>The concept of a “city in a box” is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.</p><p><em>Leslie Hook is the FT’s San Francisco correspondent</em></p><p><em>Illustration by Christopher de Lorenzo</em></p>",
-  "contentStats": {
-    "relatedBoxes": 0,
-    "pullQuotes": 0,
-    "pullQuotesWithImages": 0,
-    "bigNumbers": 0,
-    "images": 1,
-    "responsiveImages": 0,
-    "graphics": 0,
-    "videos": 0,
-    "internalVideos": 0,
-    "externalVideos": 0,
-    "subheadings": 0,
-    "curatedRecommended": 0,
-    "layouts": 0,
-    "layoutSlots": 0,
-    "infoBox": 0
-  },
+  "embeds": [
+    {
+      "apiUrl": "https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+      "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+      "copyright": {
+        "notice": "© Christopher de Lorenzo"
+      },
+      "firstPublishedDate": "2017-09-18T15:52:00.000Z",
+      "id": "ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+      "identifiers": [
+        {
+          "authority": "http://api.ft.com/system/FTCOM-METHODE",
+          "identifierValue": "ecdc60f0-97dc-11e7-a652-cde3f882dd7b"
+        }
+      ],
+      "publishReference": "tid_bz5i3bz918",
+      "publishedDate": "2017-09-18T15:52:00.000Z",
+      "type": "http://www.ft.com/ontology/content/Image",
+      "canBeSyndicated": "verify"
+    }
+  ],
+  "bodyHTML": "\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-id=\"https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" aria-hidden=\"true\" alt width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Christopher de Lorenzo\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Christopher de Lorenzo\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure>\n\t\t<p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle &#x2014; many locals love nothing more than a good gripe against Google or Uber or Amazon.</p><p>It&#x2019;s been curious, then, to watch <a href=\"/content/eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0\">cities rush forward after Amazon</a> said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company&#x2019;s favour.</p><p>The prize is certainly vast &#x2014; Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.</p><p>In Seattle, Amazon&#x2019;s hometown, however, the company&#x2019;s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon&#x2019;s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.</p><p>As the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby &#x2014; one in five walks to work &#x2014; heightening the sense that downtown Seattle has become a company town.</p><p>Suddenly Seattle&#x2019;s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington&#x2019;s low taxes were a key reason why <a href=\"https://www.ft.com/topics/people/Jeff_Bezos\">Jeff Bezos</a> set up shop there all those years ago.)</p><p>Amazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big &#x201C;Amazon&#x201D; signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres &#x2014; although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.</p><p>A similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged <a href=\"https://www.wired.com/2016/02/sfs-tech-bus-problem-isnt-about-buses-its-about-housing/\" target=\"_blank\" rel=\"noreferrer noopener\">protests</a> at the bus stops where Google&#x2019;s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.</p><p>The dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.</p><p>While big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design <a href=\"http://uk.businessinsider.com/silicon-valley-is-building-utopian-cities-2016-6?r=US&amp;IR=T\" target=\"_blank\" rel=\"noreferrer noopener\">tech-utopian cities</a> of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.</p><p>The concept of a &#x201C;city in a box&#x201D; is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.</p><p><em>Leslie Hook is the FT&#x2019;s San Francisco correspondent</em></p><p><em>Illustration by Christopher de Lorenzo</em></p>",
+  "openingHTML": "<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-id=\"https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" aria-hidden=\"true\" alt width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Christopher de Lorenzo\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Christopher de Lorenzo\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure><p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle &#x2014; many locals love nothing more than a good gripe against Google or Uber or Amazon.</p>",
+  "_editorialComponents": [],
   "url": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
   "relativeUrl": "/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
   "annotations": [
     {
-      "apiUrl": "http://api.ft.com/things/f967910f-67d5-31f7-a031-64f8af0d9cf1",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "f967910f-67d5-31f7-a031-64f8af0d9cf1",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Life & Arts",
-      "type": "SECTION",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
-      ],
-      "url": "https://www.ft.com/life-arts",
-      "preposition": "in",
-      "relativeUrl": "/life-arts"
-    },
-    {
-      "apiUrl": "http://api.ft.com/things/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "directType": "http://www.ft.com/ontology/Genre",
-      "id": "e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Comment",
-      "type": "GENRE",
-      "types": [
-        "http://www.ft.com/ontology/core/Thing",
-        "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Genre"
-      ],
-      "url": "https://www.ft.com/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-      "preposition": "",
-      "relativeUrl": "/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05"
-    },
-    {
-      "FIGI": "BBG000BVQ4Z3",
-      "apiUrl": "http://api.ft.com/organisations/23629959-5137-384a-a8af-3f7d9cb16912",
+      "FIGI": "BBG000BVPV84",
+      "apiUrl": "http://api.ft.com/organisations/84cf4073-a674-4a93-aef9-dcc1832a65cb",
       "directType": "http://www.ft.com/ontology/company/PublicCompany",
-      "id": "23629959-5137-384a-a8af-3f7d9cb16912",
+      "id": "84cf4073-a674-4a93-aef9-dcc1832a65cb",
       "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Amazon",
+      "prefLabel": "Amazon.com",
       "type": "ORGANISATION",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
@@ -110,48 +86,80 @@
         "http://www.ft.com/ontology/company/Company",
         "http://www.ft.com/ontology/company/PublicCompany"
       ],
-      "url": "https://www.ft.com/topics/organisations/Amazon",
       "preposition": "on",
-      "relativeUrl": "/topics/organisations/Amazon"
+      "url": "https://www.ft.com/stream/84cf4073-a674-4a93-aef9-dcc1832a65cb",
+      "relativeUrl": "/stream/84cf4073-a674-4a93-aef9-dcc1832a65cb"
     },
     {
-      "apiUrl": "http://api.ft.com/things/df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "FT Magazine",
-      "type": "SECTION",
+      "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+      "directType": "http://www.ft.com/ontology/Genre",
+      "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Opinion",
+      "type": "GENRE",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
+        "http://www.ft.com/ontology/Genre"
       ],
+      "preposition": "",
+      "url": "https://www.ft.com/opinion",
+      "relativeUrl": "/opinion"
+    },
+    {
+      "apiUrl": "http://api.ft.com/things/0b83bc44-4a55-4958-882e-73ba6b2b0aa6",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "0b83bc44-4a55-4958-882e-73ba6b2b0aa6",
+      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+      "prefLabel": "Life & Arts",
+      "type": "TOPIC",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "preposition": "on",
+      "url": "https://www.ft.com/life-arts",
+      "relativeUrl": "/life-arts"
+    },
+    {
+      "apiUrl": "http://api.ft.com/brands/f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+      "directType": "http://www.ft.com/ontology/product/Brand",
+      "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+      "prefLabel": "FT Magazine",
+      "type": "BRAND",
+      "types": [
+        "http://www.ft.com/ontology/core/Thing",
+        "http://www.ft.com/ontology/concept/Concept",
+        "http://www.ft.com/ontology/classification/Classification",
+        "http://www.ft.com/ontology/product/Brand"
+      ],
+      "preposition": "from",
       "url": "https://www.ft.com/magazine",
-      "preposition": "in",
       "relativeUrl": "/magazine"
     },
     {
-      "apiUrl": "http://api.ft.com/things/2dd66dcb-b87d-35ef-b1bf-ce8706f2c382",
-      "directType": "http://www.ft.com/ontology/Section",
-      "id": "2dd66dcb-b87d-35ef-b1bf-ce8706f2c382",
+      "apiUrl": "http://api.ft.com/things/6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
+      "directType": "http://www.ft.com/ontology/Topic",
+      "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
       "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Technology",
-      "type": "SECTION",
+      "prefLabel": "Technology sector",
+      "type": "TOPIC",
       "types": [
         "http://www.ft.com/ontology/core/Thing",
         "http://www.ft.com/ontology/concept/Concept",
-        "http://www.ft.com/ontology/classification/Classification",
-        "http://www.ft.com/ontology/Section"
+        "http://www.ft.com/ontology/Topic"
       ],
-      "url": "https://www.ft.com/technology",
-      "preposition": "in",
-      "relativeUrl": "/technology"
+      "preposition": "on",
+      "url": "https://www.ft.com/companies/technology",
+      "relativeUrl": "/companies/technology"
     },
     {
-      "apiUrl": "http://api.ft.com/people/0bd76a95-4aa7-358a-bf78-d70657658f53",
+      "apiUrl": "http://api.ft.com/people/14c63939-4e28-4aaa-bf44-af570a20990e",
       "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "0bd76a95-4aa7-358a-bf78-d70657658f53",
+      "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
       "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
       "prefLabel": "Leslie Hook",
       "type": "PERSON",
@@ -160,39 +168,39 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
       "preposition": "from",
-      "relativeUrl": "/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
       "attributes": [
         {
           "key": "headshot",
-          "value": "fthead:leslie-hook"
+          "value": "fthead-v1:leslie-hook"
         }
-      ]
+      ],
+      "url": "https://www.ft.com/leslie-hook",
+      "relativeUrl": "/leslie-hook"
     }
   ],
-  "displayConcept": {
-    "apiUrl": "http://api.ft.com/things/df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-    "directType": "http://www.ft.com/ontology/Section",
-    "id": "df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-    "prefLabel": "FT Magazine",
-    "type": "SECTION",
+  "genreConcept": {
+    "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+    "directType": "http://www.ft.com/ontology/Genre",
+    "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+    "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+    "prefLabel": "Opinion",
+    "type": "GENRE",
     "types": [
       "http://www.ft.com/ontology/core/Thing",
       "http://www.ft.com/ontology/concept/Concept",
       "http://www.ft.com/ontology/classification/Classification",
-      "http://www.ft.com/ontology/Section"
+      "http://www.ft.com/ontology/Genre"
     ],
-    "url": "https://www.ft.com/magazine",
-    "preposition": "in",
-    "relativeUrl": "/magazine"
+    "preposition": "",
+    "url": "https://www.ft.com/opinion",
+    "relativeUrl": "/opinion"
   },
-  "genreConcept": null,
   "authorConcepts": [
     {
-      "apiUrl": "http://api.ft.com/people/0bd76a95-4aa7-358a-bf78-d70657658f53",
+      "apiUrl": "http://api.ft.com/people/14c63939-4e28-4aaa-bf44-af570a20990e",
       "directType": "http://www.ft.com/ontology/person/Person",
-      "id": "0bd76a95-4aa7-358a-bf78-d70657658f53",
+      "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
       "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
       "prefLabel": "Leslie Hook",
       "type": "PERSON",
@@ -201,15 +209,115 @@
         "http://www.ft.com/ontology/concept/Concept",
         "http://www.ft.com/ontology/person/Person"
       ],
-      "url": "https://www.ft.com/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
       "preposition": "from",
-      "relativeUrl": "/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
       "attributes": [
         {
           "key": "headshot",
-          "value": "fthead:leslie-hook"
+          "value": "fthead-v1:leslie-hook"
         }
-      ]
+      ],
+      "url": "https://www.ft.com/leslie-hook",
+      "relativeUrl": "/leslie-hook"
     }
-  ]
+  ],
+  "design": {
+    "theme": "basic",
+    "layout": "default"
+  },
+  "displayConcept": {
+    "apiUrl": "http://api.ft.com/brands/f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+    "directType": "http://www.ft.com/ontology/product/Brand",
+    "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+    "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+    "prefLabel": "FT Magazine",
+    "type": "BRAND",
+    "types": [
+      "http://www.ft.com/ontology/core/Thing",
+      "http://www.ft.com/ontology/concept/Concept",
+      "http://www.ft.com/ontology/classification/Classification",
+      "http://www.ft.com/ontology/product/Brand"
+    ],
+    "preposition": "from",
+    "url": "https://www.ft.com/magazine",
+    "relativeUrl": "/magazine",
+    "isDisplayTag": false
+  },
+  "teaser": {
+    "id": "ef4c49fe-980e-11e7-b83c-9588e51488a0",
+    "url": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
+    "relativeUrl": "/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
+    "type": "article",
+    "indicators": {
+      "isColumn": true,
+      "isOpinion": true,
+      "isScoop": false,
+      "isExclusive": false,
+      "isEditorsChoice": false,
+      "accessLevel": "subscribed"
+    },
+    "metaPrefixText": null,
+    "metaSuffixText": null,
+    "metaLink": {
+      "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
+      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+      "prefLabel": "Leslie Hook",
+      "type": "PERSON",
+      "attributes": [
+        {
+          "key": "headshot",
+          "value": "fthead-v1:leslie-hook"
+        }
+      ],
+      "url": "https://www.ft.com/leslie-hook",
+      "relativeUrl": "/leslie-hook"
+    },
+    "metaAltLink": {
+      "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+      "prefLabel": "FT Magazine",
+      "type": "BRAND",
+      "url": "https://www.ft.com/magazine",
+      "relativeUrl": "/magazine"
+    },
+    "title": "Tech companies in the city: the backlash",
+    "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
+    "altStandfirst": null,
+    "publishedDate": "2017-09-15T04:01:25.000Z",
+    "firstPublishedDate": "2017-09-15T04:01:25.000Z",
+    "image": {
+      "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+      "width": 2048,
+      "height": 1152
+    },
+    "headshot": "fthead-v1:leslie-hook",
+    "parentTheme": null
+  },
+  "contentStats": {
+    "wordCount": 655,
+    "paragraphs": 13,
+    "relatedBoxes": 0,
+    "pullQuotes": 0,
+    "pullQuotesWithImages": 0,
+    "bigNumbers": 0,
+    "images": 1,
+    "responsiveImages": 0,
+    "graphics": 0,
+    "audio": 0,
+    "videos": 0,
+    "internalVideos": 0,
+    "externalVideos": 0,
+    "subheadings": 0,
+    "curatedRecommended": 0,
+    "layouts": 0,
+    "layoutSlots": 0,
+    "infoBox": 0,
+    "tables": 0,
+    "timelines": 0,
+    "singleArticleRecommendations": 0,
+    "sentiment": 12,
+    "scoreGraphicVolume": 0,
+    "scoreGraphicDensity": 0,
+    "scorePictureVolume": 1,
+    "scorePictureDensity": 0.001527
+  }
 }

--- a/test/fixtures/content/items.json
+++ b/test/fixtures/content/items.json
@@ -1,20 +1,23 @@
 [
     {
         "id": "42ad255a-99f9-11e7-b83c-9588e51488a0",
-        "webUrl": "http://www.ft.com/cms/s/42ad255a-99f9-11e7-b83c-9588e51488a0.html",
+        "webUrl": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
         "title": "Pound leaps to highest level since Brexit vote",
         "alternativeTitles": {
             "promotionalTitle": "Pound leaps to highest level since Brexit vote"
         },
+        "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
         "provenance": [
-            "http://api.ft.com/internalcontent/42ad255a-99f9-11e7-b83c-9588e51488a0"
+            "https://api.ft.com/internalcontent/42ad255a-99f9-11e7-b83c-9588e51488a0"
         ],
         "byline": "Roger Blitz and Kate Allen",
-        "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
-        "publishedDate": "2017-09-15T10:38:16.000Z",
+        "publishedDate": "2017-09-15T15:48:53.000Z",
         "firstPublishedDate": "2017-09-15T10:25:00.000Z",
-        "publishReference": "tid_bl0dhgy9yi",
-        "curatedRelatedContent": [ ],
+        "publishReference": "SYNTHETIC-REQ-MONtid_8mMknhpoIs_carousel_1534772577",
+        "bodyText": "The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.\n\nGertjan Vlieghe, a member of the bank’s Monetary Policy Committee who has previously been cautious about tightening policy, said “we are approaching the moment when the bank rate may need to rise”.\n\nComing a day after the MPC kept rates on hold but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the pound’s rally.\n\nInvestors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 4 basis points to 0.42 per cent, after earlier hitting a session high above 0.48 per cent. That was the highest level since the week before the EU referendum in June last year.\n\nUK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.1 per cent.\n\n“The BoE really have lined up the market for a hike,” said Jordan Rochester, a currency strategist at Nomura.\n\nSterling was last trading at $1.3589 after earlier hitting a day high of $1.3615 — this 1.4 per cent advance leaves sterling up about 3 per cent against the dollar on the week week, which began with stronger than expected inflation figures.\n\nThe currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.\n\nAlthough the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision — and Mr Vlieghe’s speech today — is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so.\n\n“The possibility of a November or February hike is real, we think,” analysts at Bank of America Merrill Lynch noted. “That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.”\n\nBefore Mr Vlieghe’s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have reservations about the shift from the bank.\n\nMr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have “a larger impact on the economy than we have seen so far”.\n\nDavid Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was “deliberately set to stabilise further the pound sterling”.\n\nThe currency’s weakness has been a strong driver of inflation and the pound’s renewed strength “will limit the inflation overshoot”.\n\nWhile strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained “many doubters” in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.\n\n“The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,” said Mr Rochester.",
+        "curatedRelatedContent": [],
+        "containedIn": [],
+        "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
         "comments": {
             "enabled": true
@@ -25,58 +28,244 @@
             "scoop": false
         },
         "realtime": false,
+        "editorialDesk": "/FT/WorldNews",
         "originatingParty": "FT",
-        "_lastUpdatedDateTime": "2017-09-15T11:08:41.343Z",
+        "_lastUpdatedDateTime": "2020-09-04T05:12:41.636Z",
+        "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
         "type": "article",
         "accessLevel": "subscribed",
-        "topper": { },
-        "leadImages": [ ],
-        "containedIn": [ ],
+        "topper": {},
         "mainImage": {
+            "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
             "title": "",
             "description": "LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer £10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer £20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)",
-            "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+            "copyright": "© Getty",
             "width": 2048,
             "height": 1152,
-            "ratio": 1.7777777777777777,
+            "ratio": 1.77778,
             "aspectRatio": 0.5625
         },
-        "bodyHTML": "<figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" alt=\"\" role=\"presentation\" width=\"2048\" height=\"1152\" data-copyright=\"© Getty\"><figcaption class=\"n-content-image__caption\">© Getty</figcaption></figure><p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p><p>Gertjan Vlieghe, a member of the <a href=\"/content/36ccf330-dc41-3ca1-8335-9cb1fe3ee21e\">bank’s Monetary Policy Committee</a> who has previously been cautious about tightening policy, said “we are approaching the moment when the bank rate may need to rise”.</p><p>Coming a day after the MPC kept <a href=\"/content/f6da0ec5-c433-3cf5-91fb-c781fe8c370b\">rates</a> on hold, but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the <a href=\"https://www.ft.com/topics/themes/Sterling\">pound</a>’s rally. </p><p>Investors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 10 basis points to 0.47 per cent. That is the highest level since the week before the <a href=\"https://www.ft.com/brexit\">EU referendum</a> in June last year.</p><p>UK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.3 per cent.</p><p>“The BoE really have lined up the market for a hike,” said Jordan Rochester, a currency strategist at Nomura.</p><figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0\" alt=\"\" role=\"presentation\" data-image-type=\"graphic\" width=\"600\" height=\"396\"></figure><p>Friday’s 1.3 per cent advance leaves sterling up almost 3 per cent against the dollar this week, which began with stronger than expected inflation figures. The currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.</p><p>Although the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision — and Mr Vlieghe’s speech today — is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so. </p><p>“The possibility of a November or February hike is real, we think,” analysts at Bank of America Merrill Lynch noted. “That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.”</p><aside class=\"n-content-recommended\" role=\"complementary\"><h3 class=\"n-content-recommended__title\">Recommended</h3><ul><li><a href=\"/content/de3e1832-97cc-11e7-b83c-9588e51488a0\">Will UK economy be turbocharged by sterling fall?</a></li><li><a href=\"/content/d43c7982-97d1-11e7-b83c-9588e51488a0\">The Bank of England’s bark is loud but it has no bite</a></li><li><a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">Bank of England’s interest rate rhetoric divides opinion</a></li></ul></aside><p>Before Mr Vlieghe’s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have <a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">reservations</a> about the shift from the bank.</p><p>Mr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have “a larger impact on the economy than we have seen so far”.</p><p>David Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was “deliberately set to stabilise further the pound sterling”.</p><p>The currency’s weakness has been a strong driver of inflation and the pound’s renewed strength “will limit the inflation overshoot”.</p><p>While strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained “many doubters” in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.</p><p>“The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,” said Mr Rochester.</p>",
-        "contentStats": {
-            "relatedBoxes": 0,
-            "pullQuotes": 0,
-            "pullQuotesWithImages": 0,
-            "bigNumbers": 0,
-            "images": 2,
-            "responsiveImages": 0,
-            "graphics": 1,
-            "videos": 0,
-            "internalVideos": 0,
-            "externalVideos": 0,
-            "subheadings": 0,
-            "curatedRecommended": 1,
-            "layouts": 0,
-            "layoutSlots": 0,
-            "infoBox": 0
-        },
+        "embeds": [
+            {
+                "apiUrl": "https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+                "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+                "canBeSyndicated": "no",
+                "copyright": {
+                    "notice": "© Getty"
+                },
+                "firstPublishedDate": "2017-09-15T10:58:00.000Z",
+                "id": "d2638930-7db3-11e7-ab01-a13271d1ee9c",
+                "identifiers": [
+                    {
+                        "authority": "http://api.ft.com/system/FTCOM-METHODE",
+                        "identifierValue": "d2638930-7db3-11e7-ab01-a13271d1ee9c"
+                    }
+                ],
+                "publishReference": "tid_btvrvczuwc",
+                "publishedDate": "2017-09-15T10:58:00.000Z",
+                "type": "http://www.ft.com/ontology/content/Image"
+            },
+            {
+                "apiUrl": "https://api.ft.com/content/69837688-9a04-11e7-b83c-9588e51488a0",
+                "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0",
+                "firstPublishedDate": "2017-09-15T11:07:00.000Z",
+                "id": "69837688-9a04-11e7-b83c-9588e51488a0",
+                "identifiers": [
+                    {
+                        "authority": "http://api.ft.com/system/FTCOM-METHODE",
+                        "identifierValue": "69837688-9a04-11e7-b83c-9588e51488a0"
+                    }
+                ],
+                "publishReference": "tid_f0y4netvt5",
+                "publishedDate": "2017-09-15T11:07:00.000Z",
+                "type": "http://www.ft.com/ontology/content/Graphic",
+                "canBeSyndicated": "verify"
+            }
+        ],
+        "bodyHTML": "\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-id=\"https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" alt=\"LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer &#xA3;10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer &#xA3;20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)\" width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Getty\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Getty\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure>\n\t\t<p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p><p>Gertjan Vlieghe, a member of the <a href=\"/content/36ccf330-dc41-3ca1-8335-9cb1fe3ee21e\">bank&#x2019;s Monetary Policy Committee</a> who has previously been cautious about tightening policy, said &#x201C;we are approaching the moment when the bank rate may need to rise&#x201D;.</p><p>Coming a day after the MPC kept <a href=\"/content/f6da0ec5-c433-3cf5-91fb-c781fe8c370b\">rates</a> on hold but gave a heavy signal it is minded to lift the base rate from a record low, the speech added fuel to the <a href=\"https://www.ft.com/topics/themes/Sterling\">pound</a>&#x2019;s rally. </p><p>Investors sold shorter dated government bonds, which are sensitive to changing expectations for the base rate, pushing the yield up 4 basis points to 0.42 per cent, after earlier hitting a session high above 0.48 per cent. That was the highest level since the week before the <a href=\"https://www.ft.com/brexit\">EU referendum</a> in June last year.</p><p>UK stocks were also hard hit by the sterling move, the FTSE 100 index sliding 1.1 per cent.</p><p>&#x201C;The BoE really have lined up the market for a hike,&#x201D; said Jordan Rochester, a currency strategist at Nomura.</p>\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/69837688-9a04-11e7-b83c-9588e51488a0\" data-id=\"https://api.ft.com/content/69837688-9a04-11e7-b83c-9588e51488a0\" data-image-type=\"graphic\" data-original-image-width=\"600\" data-original-image-height=\"396\" alt=\"A graphic with no description\" width=\"600\" height=\"396\">\n\t\t\t\t\n\t\t\t</figure>\n\t\t<p>Sterling was last trading at $1.3589 after earlier hitting a day high of $1.3615 &#x2014; this 1.4 per cent advance leaves sterling up about 3 per cent against the dollar on the week week, which began with stronger than expected inflation figures. </p><p>The currency also powered higher against the euro, rising 1.1 per cent and was trading at just under 88p versus the euro.</p><p>Although the MPC voted 7-2 to hold rates yesterday, the commentary accompanying the decision &#x2014; and Mr Vlieghe&#x2019;s speech today &#x2014; is convincing more investors that after talking about lifting rates earlier in the year, the MPC is now more serious about doing so. </p><p>&#x201C;The possibility of a November or February hike is real, we think,&#x201D; analysts at Bank of America Merrill Lynch noted. &#x201C;That said, we cannot understand why the BoE would want to hike rates just as currency effects on inflation are about to fade while domestic price pressure is non-existent. They seem to be panicking about the inflation peak rather than looking ahead to the likely sharp drop next year.&#x201D;</p>\n\t\t\t<aside class=\"n-content-recommended\" role=\"complementary\" data-editorial-component-id=\"component1\">\n\t\t\t\t<h2 class=\"n-content-recommended__title\">Recommended</h2>\n\t\t\t\t\n\t\t\t\t<ul><li><a href=\"/content/de3e1832-97cc-11e7-b83c-9588e51488a0\">Will UK economy be turbocharged by sterling fall</a>?</li><li><a href=\"/content/d43c7982-97d1-11e7-b83c-9588e51488a0\">The Bank of England&#x2019;s bark is loud but it has no bite</a></li><li><a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">Bank of England&#x2019;s interest rate rhetoric divides opinion</a></li></ul>\n\t\t\t</aside>\n\t\t<p>Before Mr Vlieghe&#x2019;s speech on Friday morning, currency analysts had thought the pound was heading to $1.35 sooner than expected, given the increasingly hawkish BoE slant and its concerns about rising inflation. Yet some have <a href=\"/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b\">reservations</a> about the shift from the bank.</p><p>Mr Vlieghe acknowledged that inflation may ease back, and that uncertainty over the outcome of the Brexit negotiations may have &#x201C;a larger impact on the economy than we have seen so far&#x201D;.</p><p>David Meier, an economist at Julius Baer, said he was sceptical about the shift in BoE tone, saying it was &#x201C;deliberately set to stabilise further the pound sterling&#x201D;.</p><p>The currency&#x2019;s weakness has been a strong driver of inflation and the pound&#x2019;s renewed strength &#x201C;will limit the inflation overshoot&#x201D;.</p><p>While strategists at Nomura now believe the BoE will raise rates in November, Mr Rochester said there remained &#x201C;many doubters&#x201D; in the market. But added that the notion the idea of the BoE turning hawkish to support the currency and rate markets was a conspiracy theory.</p><p>&#x201C;The BoE have had a continually evolving narrative towards hiking all year and now are at the brink of action,&#x201D; said Mr Rochester.</p>",
+        "openingHTML": "<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-id=\"https://api.ft.com/content/d2638930-7db3-11e7-ab01-a13271d1ee9c\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" alt=\"LONDON, ENGLAND - SEPTEMBER 27: A photo illustration of the new British five pound note, featuring security features which include a see-through window and a foil Elizabeth Tower, on September 27, 2016 in London, England. The polymer note entered circulation on September 13 and the old five pound note will cease to be legal tender in May 2017. A new polymer &#xA3;10 note, featuring Jane Austen, will enter circulation in summer 2017 and a polymer &#xA3;20 note featuring JMW Turner will enter circulation by 2020. (Photo by Jim Dyson/Getty Images)\" width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Getty\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Getty\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure><p>The pound leapt above the $1.36 mark on Friday to its highest level since the Brexit vote, as a speech from a Bank of England policymaker hardened perceptions that the central bank is moving to raise interest rates for the first time in a decade.</p>",
         "url": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
         "relativeUrl": "/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+        "_editorialComponents": [
+            {
+                "componentId": "component1",
+                "componentType": "recommended-reads",
+                "stories": [
+                    {
+                        "image": {
+                            "url": "http://prod-upp-image-read.ft.com/ad26302e-9879-11e7-8c5c-c8d8fa6961bb",
+                            "width": 2048,
+                            "height": 1152
+                        },
+                        "metaSuffixText": null,
+                        "standfirst": "Economists say Britain unlikely to repeat export boom of 25 years ago after ERM exit",
+                        "metaAltLink": null,
+                        "relativeUrl": "/content/de3e1832-97cc-11e7-b83c-9588e51488a0",
+                        "type": "article",
+                        "indicators": {
+                            "isColumn": false,
+                            "isOpinion": false,
+                            "isScoop": false,
+                            "isExclusive": false,
+                            "isEditorsChoice": false,
+                            "accessLevel": "subscribed"
+                        },
+                        "title": "Will UK economy be turbocharged by sterling fall?",
+                        "url": "https://www.ft.com/content/de3e1832-97cc-11e7-b83c-9588e51488a0",
+                        "metaPrefixText": "Analysis",
+                        "headshot": null,
+                        "id": "de3e1832-97cc-11e7-b83c-9588e51488a0",
+                        "publishedDate": "2017-09-13T14:36:51.000Z",
+                        "firstPublishedDate": "2017-09-13T14:36:51.000Z",
+                        "metaLink": {
+                            "id": "19b95057-4614-45fb-9306-4d54049354db",
+                            "predicate": "http://www.ft.com/ontology/annotation/about",
+                            "prefLabel": "Brexit",
+                            "type": "TOPIC",
+                            "url": "https://www.ft.com/brexit",
+                            "relativeUrl": "/brexit"
+                        },
+                        "parentTheme": null,
+                        "altStandfirst": null
+                    },
+                    {
+                        "image": {
+                            "url": "http://prod-upp-image-read.ft.com/0501c122-995c-11e7-8c5c-c8d8fa6961bb",
+                            "width": 2048,
+                            "height": 1152
+                        },
+                        "metaSuffixText": null,
+                        "standfirst": "Monetary policy has not tightened, despite policymakers’ repeated rate-rise signals",
+                        "metaAltLink": {
+                            "id": "d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+                            "predicate": "http://www.ft.com/ontology/annotation/about",
+                            "prefLabel": "UK interest rates",
+                            "type": "TOPIC",
+                            "url": "https://www.ft.com/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+                            "relativeUrl": "/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b"
+                        },
+                        "relativeUrl": "/content/d43c7982-97d1-11e7-b83c-9588e51488a0",
+                        "type": "article",
+                        "indicators": {
+                            "isColumn": true,
+                            "isOpinion": true,
+                            "isScoop": false,
+                            "isExclusive": false,
+                            "isEditorsChoice": false,
+                            "accessLevel": "subscribed"
+                        },
+                        "title": "The Bank of England’s bark is loud but it has no bite",
+                        "url": "https://www.ft.com/content/d43c7982-97d1-11e7-b83c-9588e51488a0",
+                        "metaPrefixText": null,
+                        "headshot": "fthead-v1:chris-giles",
+                        "id": "d43c7982-97d1-11e7-b83c-9588e51488a0",
+                        "publishedDate": "2017-09-14T16:54:53.000Z",
+                        "firstPublishedDate": "2017-09-14T16:54:53.000Z",
+                        "metaLink": {
+                            "id": "1d556016-ad16-4fe7-8724-42b3fb15ad28",
+                            "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                            "prefLabel": "Chris Giles",
+                            "type": "PERSON",
+                            "attributes": [
+                                {
+                                    "key": "headshot",
+                                    "value": "fthead-v1:chris-giles"
+                                }
+                            ],
+                            "url": "https://www.ft.com/chris-giles",
+                            "relativeUrl": "/chris-giles"
+                        },
+                        "parentTheme": null,
+                        "altStandfirst": null
+                    },
+                    {
+                        "image": {
+                            "url": "http://prod-upp-image-read.ft.com/b9d7e924-996a-11e7-8c5c-c8d8fa6961bb",
+                            "width": 2048,
+                            "height": 1152
+                        },
+                        "metaSuffixText": null,
+                        "standfirst": "Economists split over whether BoE will follow through and tighten monetary policy",
+                        "metaAltLink": null,
+                        "relativeUrl": "/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+                        "type": "article",
+                        "indicators": {
+                            "isColumn": false,
+                            "isOpinion": false,
+                            "isScoop": false,
+                            "isExclusive": false,
+                            "isEditorsChoice": false,
+                            "accessLevel": "subscribed"
+                        },
+                        "title": "Bank of England’s rate rhetoric divides opinion",
+                        "url": "https://www.ft.com/content/6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+                        "metaPrefixText": "Analysis",
+                        "headshot": null,
+                        "id": "6a21c3e0-995c-11e7-a652-cde3f882dd7b",
+                        "publishedDate": "2017-09-14T17:46:46.000Z",
+                        "firstPublishedDate": "2017-09-14T17:46:46.000Z",
+                        "metaLink": {
+                            "id": "d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+                            "predicate": "http://www.ft.com/ontology/annotation/about",
+                            "prefLabel": "UK interest rates",
+                            "type": "TOPIC",
+                            "url": "https://www.ft.com/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b",
+                            "relativeUrl": "/stream/d17153e9-f07d-49ad-8dbd-4cb23d6bbc9b"
+                        },
+                        "parentTheme": null,
+                        "altStandfirst": null
+                    }
+                ]
+            }
+        ],
         "annotations": [
             {
-                "apiUrl": "http://api.ft.com/things/1e0a2449-d86d-3b94-a888-9eb596f2592c",
+                "apiUrl": "http://api.ft.com/things/6b683eff-56c3-43d9-acfc-7511d974fc01",
+                "directType": "http://www.ft.com/ontology/Location",
+                "id": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+                "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
+                "prefLabel": "UK",
+                "type": "LOCATION",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/Location"
+                ],
+                "preposition": "on",
+                "url": "https://www.ft.com/world/uk",
+                "relativeUrl": "/world/uk"
+            },
+            {
+                "apiUrl": "http://api.ft.com/things/04126152-5bef-4dda-86bf-81f66c00a342",
                 "directType": "http://www.ft.com/ontology/Topic",
-                "id": "1e0a2449-d86d-3b94-a888-9eb596f2592c",
-                "predicate": "http://www.ft.com/ontology/annotation/about",
-                "prefLabel": "Pound Sterling",
+                "id": "04126152-5bef-4dda-86bf-81f66c00a342",
+                "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+                "prefLabel": "Currencies",
                 "type": "TOPIC",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/Topic"
                 ],
-                "url": "https://www.ft.com/topics/themes/Sterling",
                 "preposition": "on",
-                "relativeUrl": "/topics/themes/Sterling"
+                "url": "https://www.ft.com/currencies",
+                "relativeUrl": "/currencies"
+            },
+            {
+                "apiUrl": "http://api.ft.com/things/c91b1fad-1097-468b-be82-9a8ff717d54c",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Markets",
+                "type": "TOPIC",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/Topic"
+                ],
+                "preposition": "on",
+                "url": "https://www.ft.com/markets",
+                "relativeUrl": "/markets"
             },
             {
                 "apiUrl": "http://api.ft.com/people/f7428da5-c1d2-35d7-abef-95be5f382b78",
@@ -90,31 +279,14 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/stream/f7428da5-c1d2-35d7-abef-95be5f382b78",
                 "preposition": "on",
+                "url": "https://www.ft.com/stream/f7428da5-c1d2-35d7-abef-95be5f382b78",
                 "relativeUrl": "/stream/f7428da5-c1d2-35d7-abef-95be5f382b78"
             },
             {
-                "apiUrl": "http://api.ft.com/things/19e0e2af-78c6-3e3d-942b-e4fbe27516dd",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "19e0e2af-78c6-3e3d-942b-e4fbe27516dd",
-                "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-                "prefLabel": "Currencies",
-                "type": "SECTION",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
-                ],
-                "url": "https://www.ft.com/markets/currencies",
-                "preposition": "in",
-                "relativeUrl": "/markets/currencies"
-            },
-            {
-                "apiUrl": "http://api.ft.com/things/9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+                "apiUrl": "http://api.ft.com/things/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
                 "directType": "http://www.ft.com/ontology/Genre",
-                "id": "9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+                "id": "a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
                 "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
                 "prefLabel": "News",
                 "type": "GENRE",
@@ -124,63 +296,30 @@
                     "http://www.ft.com/ontology/classification/Classification",
                     "http://www.ft.com/ontology/Genre"
                 ],
-                "url": "https://www.ft.com/stream/9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
                 "preposition": "",
-                "relativeUrl": "/stream/9b40e89c-e87b-3d4f-b72c-2cf7511d2146"
+                "url": "https://www.ft.com/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+                "relativeUrl": "/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6"
             },
             {
-                "apiUrl": "http://api.ft.com/things/1a2a1a0a-7199-38b8-8a73-e651e2172471",
-                "directType": "http://www.ft.com/ontology/Location",
-                "id": "1a2a1a0a-7199-38b8-8a73-e651e2172471",
-                "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-                "prefLabel": "United Kingdom",
-                "type": "LOCATION",
+                "apiUrl": "http://api.ft.com/things/466a4700-307f-47cc-83f1-c5f97a172232",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+                "predicate": "http://www.ft.com/ontology/annotation/about",
+                "prefLabel": "Pound Sterling",
+                "type": "TOPIC",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
                     "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/Location"
+                    "http://www.ft.com/ontology/Topic"
                 ],
-                "url": "https://www.ft.com/stream/1a2a1a0a-7199-38b8-8a73-e651e2172471",
                 "preposition": "on",
-                "relativeUrl": "/stream/1a2a1a0a-7199-38b8-8a73-e651e2172471"
+                "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+                "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
             },
             {
-                "apiUrl": "http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-95cfd0884740",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "d969d76e-f8f4-34ae-bc38-95cfd0884740",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Markets",
-                "type": "SECTION",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
-                ],
-                "url": "https://www.ft.com/markets",
-                "preposition": "in",
-                "relativeUrl": "/markets"
-            },
-            {
-                "apiUrl": "http://api.ft.com/people/18915f53-6f96-3540-9d72-2e0400075201",
+                "apiUrl": "http://api.ft.com/people/dd4b519f-e896-4322-8f77-25c936eb9d32",
                 "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "18915f53-6f96-3540-9d72-2e0400075201",
-                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-                "prefLabel": "Kate Allen",
-                "type": "PERSON",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/person/Person"
-                ],
-                "url": "https://www.ft.com/stream/18915f53-6f96-3540-9d72-2e0400075201",
-                "preposition": "from",
-                "relativeUrl": "/stream/18915f53-6f96-3540-9d72-2e0400075201"
-            },
-            {
-                "apiUrl": "http://api.ft.com/people/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-                "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
+                "id": "dd4b519f-e896-4322-8f77-25c936eb9d32",
                 "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
                 "prefLabel": "Roger Blitz",
                 "type": "PERSON",
@@ -189,15 +328,115 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
                 "preposition": "from",
-                "relativeUrl": "/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d"
+                "url": "https://www.ft.com/roger-blitz",
+                "relativeUrl": "/roger-blitz"
+            },
+            {
+                "apiUrl": "http://api.ft.com/people/33b4cf11-6854-4dc5-aadb-f0a671da0753",
+                "directType": "http://www.ft.com/ontology/person/Person",
+                "id": "33b4cf11-6854-4dc5-aadb-f0a671da0753",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Kate Allen",
+                "type": "PERSON",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/person/Person"
+                ],
+                "preposition": "from",
+                "attributes": [
+                    {
+                        "key": "headshot",
+                        "value": "fthead-v1:kate-allen"
+                    }
+                ],
+                "url": "https://www.ft.com/kate-allen",
+                "relativeUrl": "/kate-allen"
+            },
+            {
+                "apiUrl": "http://api.ft.com/things/049291ca-c558-4b3d-ac99-cdc2e19dfc46",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "049291ca-c558-4b3d-ac99-cdc2e19dfc46",
+                "predicate": "http://www.ft.com/ontology/implicitlyAbout",
+                "prefLabel": "Foreign exchange",
+                "type": "TOPIC",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/Topic"
+                ],
+                "preposition": "on",
+                "url": "https://www.ft.com/reports/foreign-exchange",
+                "relativeUrl": "/reports/foreign-exchange"
             }
         ],
+        "genreConcept": {
+            "apiUrl": "http://api.ft.com/things/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+            "directType": "http://www.ft.com/ontology/Genre",
+            "id": "a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+            "prefLabel": "News",
+            "type": "GENRE",
+            "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/classification/Classification",
+                "http://www.ft.com/ontology/Genre"
+            ],
+            "preposition": "",
+            "url": "https://www.ft.com/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+            "relativeUrl": "/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6"
+        },
+        "authorConcepts": [
+            {
+                "apiUrl": "http://api.ft.com/people/dd4b519f-e896-4322-8f77-25c936eb9d32",
+                "directType": "http://www.ft.com/ontology/person/Person",
+                "id": "dd4b519f-e896-4322-8f77-25c936eb9d32",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Roger Blitz",
+                "type": "PERSON",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/person/Person"
+                ],
+                "preposition": "from",
+                "url": "https://www.ft.com/roger-blitz",
+                "relativeUrl": "/roger-blitz"
+            },
+            {
+                "apiUrl": "http://api.ft.com/people/33b4cf11-6854-4dc5-aadb-f0a671da0753",
+                "directType": "http://www.ft.com/ontology/person/Person",
+                "id": "33b4cf11-6854-4dc5-aadb-f0a671da0753",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Kate Allen",
+                "type": "PERSON",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/person/Person"
+                ],
+                "preposition": "from",
+                "attributes": [
+                    {
+                        "key": "headshot",
+                        "value": "fthead-v1:kate-allen"
+                    }
+                ],
+                "url": "https://www.ft.com/kate-allen",
+                "relativeUrl": "/kate-allen"
+            }
+        ],
+        "design": {
+            "theme": "basic",
+            "layout": "default"
+        },
         "displayConcept": {
-            "apiUrl": "http://api.ft.com/things/1e0a2449-d86d-3b94-a888-9eb596f2592c",
+            "apiUrl": "http://api.ft.com/things/466a4700-307f-47cc-83f1-c5f97a172232",
             "directType": "http://www.ft.com/ontology/Topic",
-            "id": "1e0a2449-d86d-3b94-a888-9eb596f2592c",
+            "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+            "predicate": "http://www.ft.com/ontology/annotation/about",
             "prefLabel": "Pound Sterling",
             "type": "TOPIC",
             "types": [
@@ -205,62 +444,96 @@
                 "http://www.ft.com/ontology/concept/Concept",
                 "http://www.ft.com/ontology/Topic"
             ],
-            "url": "https://www.ft.com/topics/themes/Sterling",
             "preposition": "on",
-            "relativeUrl": "/topics/themes/Sterling"
+            "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+            "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+            "isDisplayTag": false
         },
-        "genreConcept": null,
-        "authorConcepts": [
-            {
-                "apiUrl": "http://api.ft.com/people/18915f53-6f96-3540-9d72-2e0400075201",
-                "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "18915f53-6f96-3540-9d72-2e0400075201",
-                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-                "prefLabel": "Kate Allen",
-                "type": "PERSON",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/person/Person"
-                ],
-                "url": "https://www.ft.com/stream/18915f53-6f96-3540-9d72-2e0400075201",
-                "preposition": "from",
-                "relativeUrl": "/stream/18915f53-6f96-3540-9d72-2e0400075201"
+        "teaser": {
+            "id": "42ad255a-99f9-11e7-b83c-9588e51488a0",
+            "url": "https://www.ft.com/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+            "relativeUrl": "/content/42ad255a-99f9-11e7-b83c-9588e51488a0",
+            "type": "article",
+            "indicators": {
+                "isColumn": false,
+                "isOpinion": false,
+                "isScoop": false,
+                "isExclusive": false,
+                "isEditorsChoice": false,
+                "accessLevel": "subscribed"
             },
-            {
-                "apiUrl": "http://api.ft.com/people/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-                "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-                "prefLabel": "Roger Blitz",
-                "type": "PERSON",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/person/Person"
-                ],
-                "url": "https://www.ft.com/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d",
-                "preposition": "from",
-                "relativeUrl": "/stream/4c632b1d-3d26-3d54-8dab-d1a91236fc2d"
-            }
-        ]
+            "metaPrefixText": null,
+            "metaSuffixText": null,
+            "metaLink": {
+                "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+                "predicate": "http://www.ft.com/ontology/annotation/about",
+                "prefLabel": "Pound Sterling",
+                "type": "TOPIC",
+                "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+                "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
+            },
+            "metaAltLink": null,
+            "title": "Pound leaps to highest level since Brexit vote",
+            "standfirst": "Hawkish speech from BoE policymaker injects further momentum into the rally",
+            "altStandfirst": null,
+            "publishedDate": "2017-09-15T15:48:53.000Z",
+            "firstPublishedDate": "2017-09-15T10:25:00.000Z",
+            "image": {
+                "url": "http://prod-upp-image-read.ft.com/d2638930-7db3-11e7-ab01-a13271d1ee9c",
+                "width": 2048,
+                "height": 1152
+            },
+            "headshot": null,
+            "parentTheme": null
+        },
+        "contentStats": {
+            "wordCount": 555,
+            "paragraphs": 16,
+            "relatedBoxes": 0,
+            "pullQuotes": 0,
+            "pullQuotesWithImages": 0,
+            "bigNumbers": 0,
+            "images": 2,
+            "responsiveImages": 0,
+            "graphics": 1,
+            "audio": 0,
+            "videos": 0,
+            "internalVideos": 0,
+            "externalVideos": 0,
+            "subheadings": 0,
+            "curatedRecommended": 1,
+            "layouts": 0,
+            "layoutSlots": 0,
+            "infoBox": 0,
+            "tables": 0,
+            "timelines": 0,
+            "singleArticleRecommendations": 0,
+            "sentiment": 1,
+            "scoreGraphicVolume": 1,
+            "scoreGraphicDensity": 0.001802,
+            "scorePictureVolume": 1,
+            "scorePictureDensity": 0.001802
+        }
     },
     {
         "id": "ef4c49fe-980e-11e7-b83c-9588e51488a0",
-        "webUrl": "http://www.ft.com/cms/s/ef4c49fe-980e-11e7-b83c-9588e51488a0.html",
+        "webUrl": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
         "title": "Tech companies in the city: the backlash",
         "alternativeTitles": {
             "promotionalTitle": "Tech companies in the city: the backlash"
         },
+        "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
         "provenance": [
-            "http://api.ft.com/internalcontent/ef4c49fe-980e-11e7-b83c-9588e51488a0"
+            "https://api.ft.com/internalcontent/ef4c49fe-980e-11e7-b83c-9588e51488a0"
         ],
         "byline": "Leslie Hook",
-        "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
         "publishedDate": "2017-09-15T04:01:25.000Z",
         "firstPublishedDate": "2017-09-15T04:01:25.000Z",
-        "publishReference": "tid_oyutrewelx",
-        "curatedRelatedContent": [ ],
+        "publishReference": "SYNTHETIC-REQ-MONtid_Nc4lS23YUV_carousel_1534772628",
+        "bodyText": "Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle — many locals love nothing more than a good gripe against Google or Uber or Amazon.\n\nIt’s been curious, then, to watch cities rush forward after Amazon said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company’s favour.\n\nThe prize is certainly vast — Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.\n\nIn Seattle, Amazon’s hometown, however, the company’s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon’s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.\n\nAs the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby — one in five walks to work — heightening the sense that downtown Seattle has become a company town.\n\nSuddenly Seattle’s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington’s low taxes were a key reason why Jeff Bezos set up shop there all those years ago.)\n\nAmazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big “Amazon” signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres — although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.\n\nA similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged protests at the bus stops where Google’s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.\n\nThe dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.\n\nWhile big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design tech-utopian cities of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.\n\nThe concept of a “city in a box” is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.\n\nLeslie Hook is the FT’s San Francisco correspondent\n\nIllustration by Christopher de Lorenzo",
+        "curatedRelatedContent": [],
+        "containedIn": [],
+        "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
         "comments": {
             "enabled": true
@@ -271,84 +544,57 @@
             "scoop": false
         },
         "realtime": false,
+        "editorialDesk": "/FT/Weekend/The Magazine",
         "originatingParty": "FT",
-        "_lastUpdatedDateTime": "2017-09-15T07:03:59.228Z",
+        "_lastUpdatedDateTime": "2020-09-03T09:22:46.137Z",
+        "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
         "type": "article",
         "accessLevel": "subscribed",
-        "topper": { },
-        "leadImages": [ ],
-        "containedIn": [ ],
+        "topper": {},
         "mainImage": {
+            "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
             "title": "",
             "description": "",
-            "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+            "copyright": "© Christopher de Lorenzo",
             "width": 2048,
             "height": 1152,
-            "ratio": 1.7777777777777777,
+            "ratio": 1.77778,
             "aspectRatio": 0.5625
         },
-        "bodyHTML": "<figure class=\"n-content-image\"><img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" alt=\"\" role=\"presentation\" width=\"2048\" height=\"1152\" data-copyright=\"© Christopher de Lorenzo\"><figcaption class=\"n-content-image__caption\">© Christopher de Lorenzo</figcaption></figure><p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle — many locals love nothing more than a good gripe against Google or Uber or Amazon.</p><p>It’s been curious, then, to watch <a href=\"/content/eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0\">cities rush forward after Amazon</a> said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company’s favour.</p><p>The prize is certainly vast — Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.</p><p>In Seattle, Amazon’s hometown, however, the company’s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon’s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.</p><p>As the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby — one in five walks to work — heightening the sense that downtown Seattle has become a company town.</p><p>Suddenly Seattle’s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington’s low taxes were a key reason why <a href=\"https://www.ft.com/topics/people/Jeff_Bezos\">Jeff Bezos</a> set up shop there all those years ago.)</p><p>Amazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big “Amazon” signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres — although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.</p><p>A similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged <a href=\"https://www.wired.com/2016/02/sfs-tech-bus-problem-isnt-about-buses-its-about-housing/\">protests</a> at the bus stops where Google’s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.</p><p>The dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.</p><p>While big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design <a href=\"http://uk.businessinsider.com/silicon-valley-is-building-utopian-cities-2016-6?r=US&amp;IR=T\">tech-utopian cities</a> of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.</p><p>The concept of a “city in a box” is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.</p><p><em>Leslie Hook is the FT’s San Francisco correspondent</em></p><p><em>Illustration by Christopher de Lorenzo</em></p>",
-        "contentStats": {
-            "relatedBoxes": 0,
-            "pullQuotes": 0,
-            "pullQuotesWithImages": 0,
-            "bigNumbers": 0,
-            "images": 1,
-            "responsiveImages": 0,
-            "graphics": 0,
-            "videos": 0,
-            "internalVideos": 0,
-            "externalVideos": 0,
-            "subheadings": 0,
-            "curatedRecommended": 0,
-            "layouts": 0,
-            "layoutSlots": 0,
-            "infoBox": 0
-        },
+        "embeds": [
+            {
+                "apiUrl": "https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+                "binaryUrl": "http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+                "copyright": {
+                    "notice": "© Christopher de Lorenzo"
+                },
+                "firstPublishedDate": "2017-09-18T15:52:00.000Z",
+                "id": "ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+                "identifiers": [
+                    {
+                        "authority": "http://api.ft.com/system/FTCOM-METHODE",
+                        "identifierValue": "ecdc60f0-97dc-11e7-a652-cde3f882dd7b"
+                    }
+                ],
+                "publishReference": "tid_bz5i3bz918",
+                "publishedDate": "2017-09-18T15:52:00.000Z",
+                "type": "http://www.ft.com/ontology/content/Image",
+                "canBeSyndicated": "verify"
+            }
+        ],
+        "bodyHTML": "\n\t\t\t<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-id=\"https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" aria-hidden=\"true\" alt width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Christopher de Lorenzo\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Christopher de Lorenzo\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure>\n\t\t<p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle &#x2014; many locals love nothing more than a good gripe against Google or Uber or Amazon.</p><p>It&#x2019;s been curious, then, to watch <a href=\"/content/eb3642da-94b1-11e7-a9e6-11d2f0ebb7f0\">cities rush forward after Amazon</a> said it was looking for a site to build a second headquarters in North America. Mayors from Pittsburgh to Chicago to Memphis have jumped on Twitter and on the phone to woo Amazon, promising their constituents they will work hard to win the company&#x2019;s favour.</p><p>The prize is certainly vast &#x2014; Amazon has said it will spend at least $5bn to build the new headquarters, which will be home to some 50,000 employees.</p><p>In Seattle, Amazon&#x2019;s hometown, however, the company&#x2019;s presence is somewhat controversial. Any visitor is immediately struck by the scale of Amazon&#x2019;s urban campus, some 33 buildings right in the heart of town. The buildings are not walled off, but there is a noticeable change in atmosphere as you enter Amazon-land: the sidewalks get cleaner, the people have fewer tattoos and fancy fitness studios become more frequent.</p><p>As the campus has ballooned from 20,000 people two years ago to more than 40,000 people today, its footprint has become a sore point. Many workers live nearby &#x2014; one in five walks to work &#x2014; heightening the sense that downtown Seattle has become a company town.</p><p>Suddenly Seattle&#x2019;s conversations about rent control, a practice long banned in Washington state, have become serious. Seattle even elected its first socialist city council member in many decades in 2014, who campaigned in part on concerns about affordable housing and gentrification. None of this used to happen in the city, long known as a low-tax, business-friendly jurisdiction. (Washington&#x2019;s low taxes were a key reason why <a href=\"https://www.ft.com/topics/people/Jeff_Bezos\">Jeff Bezos</a> set up shop there all those years ago.)</p><p>Amazon has not been totally blind to these concerns. As if to mute its presence, the company has avoided any big &#x201C;Amazon&#x201D; signs on building exteriors. It is also creating a botanical garden in the centre of Seattle, housed in three greenhouse spheres &#x2014; although these will not be fully open to the public. Instead they will be used mostly for corporate meetings.</p><p>A similar frisson with big tech has long been felt in San Francisco, where locals harbour deep resentment for the hordes of tech workers that have flooded the city. For years, irritated San Franciscans staged <a href=\"https://www.wired.com/2016/02/sfs-tech-bus-problem-isnt-about-buses-its-about-housing/\" target=\"_blank\" rel=\"noreferrer noopener\">protests</a> at the bus stops where Google&#x2019;s fleet of big white commuter buses picked up city-dwelling tech workers with their lattes and even their dogs, to ferry them to company headquarters in Silicon Valley. These protests have died down recently, partly because soaring rents in the city have priced out many former and would-be protesters.</p><p>The dispute between cities and the tech corporations boils down to the question of what it means for companies to be good corporate citizens. The inefficiencies of government mean that cities are often unable to cope with rapid change, even while an increased tax base may help fill city coffers. Companies must then try to fill in infrastructure gaps themselves, but often these efforts draw the ire of the public, which perceives them as only benefiting the corporations and their staff.</p><p>While big tech companies are trying to manage the backlash from the cities they inhabit, a growing number of start-ups are trying to design <a href=\"http://uk.businessinsider.com/silicon-valley-is-building-utopian-cities-2016-6?r=US&amp;IR=T\" target=\"_blank\" rel=\"noreferrer noopener\">tech-utopian cities</a> of the future. These groups are working on 3D-printed buildings, trains that move at close to the speed of sound and new systems of banking and taxation that could replace the role of government as we know it.</p><p>The concept of a &#x201C;city in a box&#x201D; is often tossed around, as if these urban visions will spring forth fully formed once the technology is perfected. But before they invent the cities of the future, tech companies must first learn how to live within the cities of today.</p><p><em>Leslie Hook is the FT&#x2019;s San Francisco correspondent</em></p><p><em>Illustration by Christopher de Lorenzo</em></p>",
+        "openingHTML": "<figure class=\"n-content-image\">\n\t\t\t\t<img src=\"http://com.ft.imagepublish.prod.s3.amazonaws.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-id=\"https://api.ft.com/content/ecdc60f0-97dc-11e7-a652-cde3f882dd7b\" data-image-type=\"image\" data-original-image-width=\"2048\" data-original-image-height=\"1152\" aria-hidden=\"true\" alt width=\"2048\" height=\"1152\" data-copyright=\"&#xA9; Christopher de Lorenzo\">\n\t\t\t\t\n\t\t\t<figcaption class=\"n-content-image__caption\">\n\t\t\t\t&#xA9; Christopher de Lorenzo\n\t\t\t</figcaption>\n\t\t\n\t\t\t</figure><p>Cities and big tech companies usually do not get along very well. Just look at San Francisco or Seattle &#x2014; many locals love nothing more than a good gripe against Google or Uber or Amazon.</p>",
+        "_editorialComponents": [],
         "url": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
         "relativeUrl": "/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
         "annotations": [
             {
-                "apiUrl": "http://api.ft.com/things/f967910f-67d5-31f7-a031-64f8af0d9cf1",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "f967910f-67d5-31f7-a031-64f8af0d9cf1",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Life & Arts",
-                "type": "SECTION",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
-                ],
-                "url": "https://www.ft.com/life-arts",
-                "preposition": "in",
-                "relativeUrl": "/life-arts"
-            },
-            {
-                "apiUrl": "http://api.ft.com/things/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "directType": "http://www.ft.com/ontology/Genre",
-                "id": "e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Comment",
-                "type": "GENRE",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Genre"
-                ],
-                "url": "https://www.ft.com/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "preposition": "",
-                "relativeUrl": "/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05"
-            },
-            {
-                "FIGI": "BBG000BVQ4Z3",
-                "apiUrl": "http://api.ft.com/organisations/23629959-5137-384a-a8af-3f7d9cb16912",
+                "FIGI": "BBG000BVPV84",
+                "apiUrl": "http://api.ft.com/organisations/84cf4073-a674-4a93-aef9-dcc1832a65cb",
                 "directType": "http://www.ft.com/ontology/company/PublicCompany",
-                "id": "23629959-5137-384a-a8af-3f7d9cb16912",
+                "id": "84cf4073-a674-4a93-aef9-dcc1832a65cb",
                 "predicate": "http://www.ft.com/ontology/annotation/about",
-                "prefLabel": "Amazon",
+                "prefLabel": "Amazon.com",
                 "type": "ORGANISATION",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
@@ -357,48 +603,80 @@
                     "http://www.ft.com/ontology/company/Company",
                     "http://www.ft.com/ontology/company/PublicCompany"
                 ],
-                "url": "https://www.ft.com/topics/organisations/Amazon",
                 "preposition": "on",
-                "relativeUrl": "/topics/organisations/Amazon"
+                "url": "https://www.ft.com/stream/84cf4073-a674-4a93-aef9-dcc1832a65cb",
+                "relativeUrl": "/stream/84cf4073-a674-4a93-aef9-dcc1832a65cb"
             },
             {
-                "apiUrl": "http://api.ft.com/things/df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-                "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-                "prefLabel": "FT Magazine",
-                "type": "SECTION",
+                "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+                "directType": "http://www.ft.com/ontology/Genre",
+                "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Opinion",
+                "type": "GENRE",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
+                    "http://www.ft.com/ontology/Genre"
                 ],
+                "preposition": "",
+                "url": "https://www.ft.com/opinion",
+                "relativeUrl": "/opinion"
+            },
+            {
+                "apiUrl": "http://api.ft.com/things/0b83bc44-4a55-4958-882e-73ba6b2b0aa6",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "0b83bc44-4a55-4958-882e-73ba6b2b0aa6",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Life & Arts",
+                "type": "TOPIC",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/Topic"
+                ],
+                "preposition": "on",
+                "url": "https://www.ft.com/life-arts",
+                "relativeUrl": "/life-arts"
+            },
+            {
+                "apiUrl": "http://api.ft.com/brands/f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+                "directType": "http://www.ft.com/ontology/product/Brand",
+                "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+                "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+                "prefLabel": "FT Magazine",
+                "type": "BRAND",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/classification/Classification",
+                    "http://www.ft.com/ontology/product/Brand"
+                ],
+                "preposition": "from",
                 "url": "https://www.ft.com/magazine",
-                "preposition": "in",
                 "relativeUrl": "/magazine"
             },
             {
-                "apiUrl": "http://api.ft.com/things/2dd66dcb-b87d-35ef-b1bf-ce8706f2c382",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "2dd66dcb-b87d-35ef-b1bf-ce8706f2c382",
+                "apiUrl": "http://api.ft.com/things/6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
                 "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Technology",
-                "type": "SECTION",
+                "prefLabel": "Technology sector",
+                "type": "TOPIC",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
                     "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
+                    "http://www.ft.com/ontology/Topic"
                 ],
-                "url": "https://www.ft.com/technology",
-                "preposition": "in",
-                "relativeUrl": "/technology"
+                "preposition": "on",
+                "url": "https://www.ft.com/companies/technology",
+                "relativeUrl": "/companies/technology"
             },
             {
-                "apiUrl": "http://api.ft.com/people/0bd76a95-4aa7-358a-bf78-d70657658f53",
+                "apiUrl": "http://api.ft.com/people/14c63939-4e28-4aaa-bf44-af570a20990e",
                 "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "0bd76a95-4aa7-358a-bf78-d70657658f53",
+                "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
                 "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
                 "prefLabel": "Leslie Hook",
                 "type": "PERSON",
@@ -407,39 +685,39 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
                 "preposition": "from",
-                "relativeUrl": "/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
                 "attributes": [
                     {
                         "key": "headshot",
-                        "value": "fthead:leslie-hook"
+                        "value": "fthead-v1:leslie-hook"
                     }
-                ]
+                ],
+                "url": "https://www.ft.com/leslie-hook",
+                "relativeUrl": "/leslie-hook"
             }
         ],
-        "displayConcept": {
-            "apiUrl": "http://api.ft.com/things/df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-            "directType": "http://www.ft.com/ontology/Section",
-            "id": "df5190e2-20f9-379b-9054-06ecfbdcb3a0",
-            "prefLabel": "FT Magazine",
-            "type": "SECTION",
+        "genreConcept": {
+            "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+            "directType": "http://www.ft.com/ontology/Genre",
+            "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+            "prefLabel": "Opinion",
+            "type": "GENRE",
             "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
                 "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
+                "http://www.ft.com/ontology/Genre"
             ],
-            "url": "https://www.ft.com/magazine",
-            "preposition": "in",
-            "relativeUrl": "/magazine"
+            "preposition": "",
+            "url": "https://www.ft.com/opinion",
+            "relativeUrl": "/opinion"
         },
-        "genreConcept": null,
         "authorConcepts": [
             {
-                "apiUrl": "http://api.ft.com/people/0bd76a95-4aa7-358a-bf78-d70657658f53",
+                "apiUrl": "http://api.ft.com/people/14c63939-4e28-4aaa-bf44-af570a20990e",
                 "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "0bd76a95-4aa7-358a-bf78-d70657658f53",
+                "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
                 "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
                 "prefLabel": "Leslie Hook",
                 "type": "PERSON",
@@ -448,69 +726,165 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
                 "preposition": "from",
-                "relativeUrl": "/stream/0bd76a95-4aa7-358a-bf78-d70657658f53",
                 "attributes": [
                     {
                         "key": "headshot",
-                        "value": "fthead:leslie-hook"
+                        "value": "fthead-v1:leslie-hook"
                     }
-                ]
+                ],
+                "url": "https://www.ft.com/leslie-hook",
+                "relativeUrl": "/leslie-hook"
             }
-        ]
+        ],
+        "design": {
+            "theme": "basic",
+            "layout": "default"
+        },
+        "displayConcept": {
+            "apiUrl": "http://api.ft.com/brands/f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+            "directType": "http://www.ft.com/ontology/product/Brand",
+            "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+            "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+            "prefLabel": "FT Magazine",
+            "type": "BRAND",
+            "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/classification/Classification",
+                "http://www.ft.com/ontology/product/Brand"
+            ],
+            "preposition": "from",
+            "url": "https://www.ft.com/magazine",
+            "relativeUrl": "/magazine",
+            "isDisplayTag": false
+        },
+        "teaser": {
+            "id": "ef4c49fe-980e-11e7-b83c-9588e51488a0",
+            "url": "https://www.ft.com/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
+            "relativeUrl": "/content/ef4c49fe-980e-11e7-b83c-9588e51488a0",
+            "type": "article",
+            "indicators": {
+                "isColumn": true,
+                "isOpinion": true,
+                "isScoop": false,
+                "isExclusive": false,
+                "isEditorsChoice": false,
+                "accessLevel": "subscribed"
+            },
+            "metaPrefixText": null,
+            "metaSuffixText": null,
+            "metaLink": {
+                "id": "14c63939-4e28-4aaa-bf44-af570a20990e",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Leslie Hook",
+                "type": "PERSON",
+                "attributes": [
+                    {
+                        "key": "headshot",
+                        "value": "fthead-v1:leslie-hook"
+                    }
+                ],
+                "url": "https://www.ft.com/leslie-hook",
+                "relativeUrl": "/leslie-hook"
+            },
+            "metaAltLink": {
+                "id": "f12aa89a-5506-4a68-aff6-4ce78d0e709f",
+                "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+                "prefLabel": "FT Magazine",
+                "type": "BRAND",
+                "url": "https://www.ft.com/magazine",
+                "relativeUrl": "/magazine"
+            },
+            "title": "Tech companies in the city: the backlash",
+            "standfirst": "‘As Seattle’s Amazon-land ballooned, its footprint became a sore point’",
+            "altStandfirst": null,
+            "publishedDate": "2017-09-15T04:01:25.000Z",
+            "firstPublishedDate": "2017-09-15T04:01:25.000Z",
+            "image": {
+                "url": "http://prod-upp-image-read.ft.com/ecdc60f0-97dc-11e7-a652-cde3f882dd7b",
+                "width": 2048,
+                "height": 1152
+            },
+            "headshot": "fthead-v1:leslie-hook",
+            "parentTheme": null
+        },
+        "contentStats": {
+            "wordCount": 655,
+            "paragraphs": 13,
+            "relatedBoxes": 0,
+            "pullQuotes": 0,
+            "pullQuotesWithImages": 0,
+            "bigNumbers": 0,
+            "images": 1,
+            "responsiveImages": 0,
+            "graphics": 0,
+            "audio": 0,
+            "videos": 0,
+            "internalVideos": 0,
+            "externalVideos": 0,
+            "subheadings": 0,
+            "curatedRecommended": 0,
+            "layouts": 0,
+            "layoutSlots": 0,
+            "infoBox": 0,
+            "tables": 0,
+            "timelines": 0,
+            "singleArticleRecommendations": 0,
+            "sentiment": 12,
+            "scoreGraphicVolume": 0,
+            "scoreGraphicDensity": 0,
+            "scorePictureVolume": 1,
+            "scorePictureDensity": 0.001527
+        }
     },
     {
         "id": "b16fce7e-3c92-48a3-ace0-d1af3fce71af",
-        "webUrl": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+        "webUrl": "https://www.ft.com/content/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
         "title": "Mental health and the gig economy",
+        "alternativeTitles": {},
+        "standfirst": "Flexibility is good for workers, but can bring health problems",
         "provenance": [
-            "http://api.ft.com/internalcontent/b16fce7e-3c92-48a3-ace0-d1af3fce71af"
+            "https://api.ft.com/internalcontent/b16fce7e-3c92-48a3-ace0-d1af3fce71af"
         ],
         "byline": "Graphics by Aslan Livingstone-Ra. Produced by Seb Morton-Clark and Emma Boyde.",
-        "standfirst": "Flexibility is good for workers, but can bring health problems",
         "publishedDate": "2017-09-13T12:15:43.662Z",
         "firstPublishedDate": "2017-09-13T12:15:43.662Z",
         "publishReference": "tid_eg4yqbdeuh",
         "curatedRelatedContent": [
             {
-                "apiUrl": "http://api.ft.com/content/749cb87e-6ca8-11e7-b9c7-15af748b60d0",
-                "id": "749cb87e-6ca8-11e7-b9c7-15af748b60d0"
+                "id": "749cb87e-6ca8-11e7-b9c7-15af748b60d0",
+                "apiUrl": "http://api.ft.com/content/749cb87e-6ca8-11e7-b9c7-15af748b60d0"
             },
             {
-                "apiUrl": "http://api.ft.com/content/dddf09c6-77a8-11e7-a3e8-60495fe6ca71",
-                "id": "dddf09c6-77a8-11e7-a3e8-60495fe6ca71"
+                "id": "dddf09c6-77a8-11e7-a3e8-60495fe6ca71",
+                "apiUrl": "http://api.ft.com/content/dddf09c6-77a8-11e7-a3e8-60495fe6ca71"
             },
             {
-                "apiUrl": "http://api.ft.com/content/d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa",
-                "id": "d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa"
+                "id": "d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa",
+                "apiUrl": "http://api.ft.com/content/d9d59684-6ca3-11e7-bfeb-33fe0c5b7eaa"
             },
             {
-                "apiUrl": "http://api.ft.com/content/398df8c0-67b1-11e7-8526-7b38dcaef614",
-                "id": "398df8c0-67b1-11e7-8526-7b38dcaef614"
+                "id": "398df8c0-67b1-11e7-8526-7b38dcaef614",
+                "apiUrl": "http://api.ft.com/content/398df8c0-67b1-11e7-8526-7b38dcaef614"
             }
         ],
+        "containedIn": [],
+        "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
         "comments": {
             "enabled": false
         },
-        "standout": { },
+        "standout": {},
         "realtime": false,
         "originatingParty": "FT",
-        "_lastUpdatedDateTime": "2017-09-13T13:16:07.651Z",
+        "_lastUpdatedDateTime": "2020-09-02T22:31:44.236Z",
+        "_lastUpdatedVersion": "fc268c176f0ba875ad15b6671e797dda89a9cc3b",
         "type": "video",
         "description": "Workers appreciate the flexibility of the gig economy, but isolation, long hours and performance assessment by an algorithm are contributing to mental health problems",
         "bodyHTML": "<p>[MUSIC PLAYING] </p><p>Everyone is talking about the gig economy. But what exactly are they talking about? Is it big or small, exciting or terrifying? Good for you health or bad for it? </p><p>The first thing to know about the gig economy is that not everyone actually agrees on what it means. As the name suggests, it's about people who earn money from doing a series of gigs or tasks. But some people use that term to apply to everyone who works independently, including lawyers and plumbers, but, of course, the notion of working for yourself is nothing new. </p><p>What is new is the invention of digital platforms that connect customers with workers to perform tasks on demand. That task could be to do someone's ironing, translate a document from Arabic to English, deliver a pizza, or drive someone home from a nightclub. There are a host of gig economy platforms, from Upwork or HourlyNerd, for tasks that are done online, to Uber and Deliveroo, for tasks that are done in person. </p><p>The uniting feature is that they match workers to customers, and they use their technology to facilitate the payment, while taking a cut for themselves. They say they're intermediaries, not employers. Others disagree. That's a question being thrashed out in courts in the US, the UK, and elsewhere. </p><p>If you live in a city teeming with Ubers, you might think the gig economy is huge already, but, actually, the number working in it is still pretty small, but it is significant. In the UK, one think tank says about 3 and 1/2% of the workforce are in the gig economy. That's about the same number as work for the National Health Service, the UK'S largest employer. </p><p>This is a growing army of workers without work places, colleagues, or bosses. What does that mean for their health and safety? </p><p>In some ways, it could be positive. The gig economy is based on the idea of working whenever you want. Having a job where you can easily nip out to deal with something personal, studies show that's one of the best indicators for high well-being. </p><p>But some health experts are worried. Flexibility might be good for your health, but loneliness and isolation are bad for it. </p><p>Gig workers don't have line managers to keep an eye out for them. Instead, their regular contact is with an algorithm that doesn't know how they're feeling today, or what personal problems might have cropped up. The algorithm just sends them tasks and monitors their performance. </p><p>Some algorithms also deactivate workers from their platforms, if there are performance issues. That can create pressure. And when the platform sets the fee per task, some workers feel they can only increase their earnings by working ever longer hours. </p><p>Driving or cycling and traffic can be dangerous at the best of times, let alone when you're tired and stressed. </p><p>For health experts, one thing is clear, there's an urgent need to investigate the benefits and the risks of this new world of work. </p><p>[MUSIC PLAYING] </p>",
+        "bodyText": "[MUSIC PLAYING]\n\nEveryone is talking about the gig economy. But what exactly are they talking about? Is it big or small, exciting or terrifying? Good for you health or bad for it?\n\nThe first thing to know about the gig economy is that not everyone actually agrees on what it means. As the name suggests, it's about people who earn money from doing a series of gigs or tasks. But some people use that term to apply to everyone who works independently, including lawyers and plumbers, but, of course, the notion of working for yourself is nothing new.\n\nWhat is new is the invention of digital platforms that connect customers with workers to perform tasks on demand. That task could be to do someone's ironing, translate a document from Arabic to English, deliver a pizza, or drive someone home from a nightclub. There are a host of gig economy platforms, from Upwork or HourlyNerd, for tasks that are done online, to Uber and Deliveroo, for tasks that are done in person.\n\nThe uniting feature is that they match workers to customers, and they use their technology to facilitate the payment, while taking a cut for themselves. They say they're intermediaries, not employers. Others disagree. That's a question being thrashed out in courts in the US, the UK, and elsewhere.\n\nIf you live in a city teeming with Ubers, you might think the gig economy is huge already, but, actually, the number working in it is still pretty small, but it is significant. In the UK, one think tank says about 3 and 1/2% of the workforce are in the gig economy. That's about the same number as work for the National Health Service, the UK'S largest employer.\n\nThis is a growing army of workers without work places, colleagues, or bosses. What does that mean for their health and safety?\n\nIn some ways, it could be positive. The gig economy is based on the idea of working whenever you want. Having a job where you can easily nip out to deal with something personal, studies show that's one of the best indicators for high well-being.\n\nBut some health experts are worried. Flexibility might be good for your health, but loneliness and isolation are bad for it.\n\nGig workers don't have line managers to keep an eye out for them. Instead, their regular contact is with an algorithm that doesn't know how they're feeling today, or what personal problems might have cropped up. The algorithm just sends them tasks and monitors their performance.\n\nSome algorithms also deactivate workers from their platforms, if there are performance issues. That can create pressure. And when the platform sets the fee per task, some workers feel they can only increase their earnings by working ever longer hours.\n\nDriving or cycling and traffic can be dangerous at the best of times, let alone when you're tired and stressed.\n\nFor health experts, one thing is clear, there's an urgent need to investigate the benefits and the risks of this new world of work.\n\n[MUSIC PLAYING]",
         "url": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
-        "mainImage": {
-            "title": "mas-gig.png",
-            "description": "",
-            "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
-            "width": 2048,
-            "height": 1152,
-            "ratio": 1.7777777777777777,
-            "aspectRatio": 0.5625
-        },
         "attachments": [
             {
                 "url": "https://next-media-api.ft.com/renditions/15053038942430/640x360.mp4",
@@ -541,30 +915,21 @@
                 "url": "https://next-media-api.ft.com/captions/15053038942430.vtt"
             }
         ],
-        "containedIn": [ ],
         "relativeUrl": "/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+        "mainImage": {
+            "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
+            "title": "mas-gig.png",
+            "description": "",
+            "width": 2048,
+            "height": 1152,
+            "ratio": 1.77778,
+            "aspectRatio": 0.5625
+        },
         "annotations": [
             {
-                "apiUrl": "http://api.ft.com/things/852939c8-859c-361e-8514-f82f6c041580",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "852939c8-859c-361e-8514-f82f6c041580",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Companies",
-                "type": "SECTION",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
-                ],
-                "url": "https://www.ft.com/companies",
-                "preposition": "in",
-                "relativeUrl": "/companies"
-            },
-            {
-                "apiUrl": "http://api.ft.com/things/b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
+                "apiUrl": "http://api.ft.com/things/596c35ec-bdb3-409a-83fb-717ecd3dc029",
                 "directType": "http://www.ft.com/ontology/Genre",
-                "id": "b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
+                "id": "596c35ec-bdb3-409a-83fb-717ecd3dc029",
                 "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
                 "prefLabel": "Explainer",
                 "type": "GENRE",
@@ -574,69 +939,145 @@
                     "http://www.ft.com/ontology/classification/Classification",
                     "http://www.ft.com/ontology/Genre"
                 ],
-                "url": "https://www.ft.com/stream/b2fa15d1-56b4-3767-8bcd-595b23a5ff22",
                 "preposition": "",
-                "relativeUrl": "/stream/b2fa15d1-56b4-3767-8bcd-595b23a5ff22"
+                "url": "https://www.ft.com/explainer",
+                "relativeUrl": "/explainer"
+            },
+            {
+                "apiUrl": "http://api.ft.com/things/c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+                "directType": "http://www.ft.com/ontology/Topic",
+                "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Companies",
+                "type": "TOPIC",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/Topic"
+                ],
+                "preposition": "on",
+                "url": "https://www.ft.com/companies",
+                "relativeUrl": "/companies"
             }
         ],
-        "displayConcept": {
-            "apiUrl": "http://api.ft.com/things/852939c8-859c-361e-8514-f82f6c041580",
-            "directType": "http://www.ft.com/ontology/Section",
-            "id": "852939c8-859c-361e-8514-f82f6c041580",
-            "prefLabel": "Companies",
-            "type": "SECTION",
+        "genreConcept": {
+            "apiUrl": "http://api.ft.com/things/596c35ec-bdb3-409a-83fb-717ecd3dc029",
+            "directType": "http://www.ft.com/ontology/Genre",
+            "id": "596c35ec-bdb3-409a-83fb-717ecd3dc029",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+            "prefLabel": "Explainer",
+            "type": "GENRE",
             "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
                 "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
+                "http://www.ft.com/ontology/Genre"
             ],
-            "url": "https://www.ft.com/companies",
-            "preposition": "in",
-            "relativeUrl": "/companies"
+            "preposition": "",
+            "url": "https://www.ft.com/explainer",
+            "relativeUrl": "/explainer"
         },
-        "genreConcept": null,
-        "authorConcepts": [ ]
+        "authorConcepts": [],
+        "design": {
+            "theme": "basic",
+            "layout": "default"
+        },
+        "displayConcept": {
+            "apiUrl": "http://api.ft.com/things/c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+            "directType": "http://www.ft.com/ontology/Topic",
+            "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+            "prefLabel": "Companies",
+            "type": "TOPIC",
+            "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+            ],
+            "preposition": "on",
+            "url": "https://www.ft.com/companies",
+            "relativeUrl": "/companies",
+            "isDisplayTag": false
+        },
+        "teaser": {
+            "id": "b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+            "url": "https://www.ft.com/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+            "relativeUrl": "/video/b16fce7e-3c92-48a3-ace0-d1af3fce71af",
+            "type": "video",
+            "indicators": {
+                "isColumn": false,
+                "isOpinion": false,
+                "isScoop": false,
+                "isExclusive": false,
+                "isEditorsChoice": false,
+                "accessLevel": "subscribed"
+            },
+            "metaPrefixText": "Explainer",
+            "metaSuffixText": "3 min",
+            "metaLink": {
+                "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Companies",
+                "type": "TOPIC",
+                "url": "https://www.ft.com/companies",
+                "relativeUrl": "/companies"
+            },
+            "metaAltLink": null,
+            "title": "Mental health and the gig economy",
+            "standfirst": "Flexibility is good for workers, but can bring health problems",
+            "altStandfirst": null,
+            "publishedDate": "2017-09-13T12:15:43.662Z",
+            "firstPublishedDate": "2017-09-13T12:15:43.662Z",
+            "image": {
+                "url": "http://prod-upp-image-read.ft.com/7156ce33-3a5a-43b9-83ce-2206337d2784",
+                "width": 2048,
+                "height": 1152
+            },
+            "video": {
+                "url": "https://next-media-api.ft.com/renditions/15053038942430/640x360.mp4",
+                "width": 640,
+                "height": 360,
+                "duration": 178943,
+                "codec": "h264",
+                "mediaType": "video/mp4"
+            }
+        }
     },
     {
         "id": "a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
-        "webUrl": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+        "webUrl": "https://www.ft.com/content/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
         "title": "Is being authentic enough to be a leader?",
+        "alternativeTitles": {},
+        "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
         "provenance": [
-            "http://api.ft.com/internalcontent/a1af0574-eafb-41bd-aa4f-59aa2cd084c2"
+            "https://api.ft.com/internalcontent/a1af0574-eafb-41bd-aa4f-59aa2cd084c2"
         ],
         "byline": "Produced by Alessia Giustiniano. Filmed by Rod Fitzgerald.",
-        "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
         "publishedDate": "2017-09-13T17:10:52.586Z",
         "firstPublishedDate": "2017-09-13T17:10:52.586Z",
         "publishReference": "tid_updlmq8ym2",
         "curatedRelatedContent": [
             {
-                "apiUrl": "http://api.ft.com/content/996fbb84-96d7-11e7-b83c-9588e51488a0",
-                "id": "996fbb84-96d7-11e7-b83c-9588e51488a0"
+                "id": "996fbb84-96d7-11e7-b83c-9588e51488a0",
+                "apiUrl": "http://api.ft.com/content/996fbb84-96d7-11e7-b83c-9588e51488a0"
             }
         ],
+        "containedIn": [],
+        "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
         "comments": {
             "enabled": false
         },
-        "standout": { },
+        "standout": {},
         "realtime": false,
         "originatingParty": "FT",
-        "_lastUpdatedDateTime": "2017-09-13T17:37:35.924Z",
+        "_lastUpdatedDateTime": "2020-09-02T03:05:43.205Z",
+        "_lastUpdatedVersion": "a96145043202ee9d2483edd57d2de1b23e695e7a",
         "type": "video",
         "description": "The FT's editor Lionel Barber and Janan Ganesh, our chief political commentator, discuss the recent political party candidates and examine whether being authentic is sufficient to be an effective leader.",
         "bodyHTML": "<p>The British political season is almost upon us. And many people are asking, might Theresa May face a leadership challenge. And what about the leadership qualities of Jeremy Corbyn newly rejuvenated? What is the ultimate test of leadership? Is it authenticity? Here with me to discuss this is Janan Ganesh and you made a quite extraordinary attack this week on authenticity and a putative challenger to Mrs. May, Jacob Rees-Mogg. </p><p>Yeah, authenticity has become the gold dust when looking for political candidates in the modern world. Jeremy Corbyn is seen to have done well as labour leader because he has authenticity. Boris Johnson for a long time looked like a plausible prime minister because people said, well, he's authentic. He's unspun. But I think him Jacob Rees-Mogg you have an example of someone who's clearly authentic, doesn't disguise the fact that he's a very privileged man, and doesn't disguise the fact that he's-- </p><p>Some of the times editor. </p><p>Former newspaper editor. </p><p>William Rees-Mogg. </p><p>But doesn't also disguise the fact that he's a committed Catholic. And he expressed views on abortion and same-sex marriage that annoyed a lot of people who were big fans of him only two weeks ago. And that's an example of the fact that when people say they want authenticity, what they mean is the kind of authenticity they like. </p><p>Yeah but-- </p><p>There's good authenticity and then there's the bad stuff, which they suddenly go cold over. </p><p>Yeah, but Janan, I mean, we watched the British election campaign earlier this year in which Theresa May, for all her qualities, was incapable of spontaneous talking, speaking on the trail. And she wasn't authentic. </p><p>She could argue that that was the authentic her, that she's not a natural public performer. She's not a natural people person. Actually she's a diligent, behind-the-scenes kind of politician who works through a brief and does her best in that way, rather than a spectacular personality. But that's fine. The problem I have with the authenticity cult is that people think it's somehow enough. That if someone is expressive of views that are unusual, doesn't employ a media adviser, it's very direct-- </p><p>That's the point about media advisers. I mean, you know, I've covered American presidential campaigns. I mean, they're all over the place. You get the blow dried hair cut candidate. </p><p>Yeah. </p><p>And he's totally scripted or she's totally scripted. Look at Hillary Clinton last year. </p><p>And that's annoying to a lot of people and hard to connect with. But in office, is it enough to say, well, I'm authentic and, therefore, I should be national leader of a country of 60 million people with nuclear weapons and a very large economy. I think authenticity is not even necessary, let alone sufficient. And we started to talk about it as though it was almost a sufficient criterion on which to elect a national leader. </p><p>Well, I'm coming round to your point of view. But what about Jeremy Corbyn? I mean, isn't he authentic? I mean, the flat cap, the beard has been trimmed now, of course. </p><p>A bit, yeah. </p><p>But you know, he is what he looks like, which is a 1970s style socialist. </p><p>Completely, I think he's entirely authentic. Hasn't changed his views since he entered parliament in the early 1980s, completely unspun, slight trimming of the beard. I think he started to wear a suit now, or at least a jacket and tie but nothing artificial really. But is that a sufficient criterion on which to elect a national leader? And my only-- </p><p>So what are the qualities that we need? And if we're going to put authenticity slightly to the side, not completely-- </p><p>Yeah. </p><p>What are we looking at? </p><p>I think that-- I still think a good national leader will, to a large extent, be inauthentic. And we will find them objectionable in many ways. And so someone like a Tony Blair or a John Major was seen to be sometimes underhand to not say the entirety of what they mean. And that's necessary. You're having to balance interests within your cabinet. You're having to balance principle with practical reality. You're having to set this interest group up against that one and somehow keep some semblance of popularity while governing the country. </p><p>You can only do that as a national leader if you are a little bit sly, a little bit inauthentic, and are willing to not say absolutely everything you mean at any given time. So I think it's almost kind of weirdly juvenile demand that we, as the media, and to a certain extent the electorate have come up with in expecting everyone to be completely honest and authentic all the time. </p><p>So I'm writing down Jacob Rees-Mogg's chances of being the next Conservative Party leader. Thank you Janan Ganesh. </p><p>Thank you. </p>",
+        "bodyText": "The British political season is almost upon us. And many people are asking, might Theresa May face a leadership challenge. And what about the leadership qualities of Jeremy Corbyn newly rejuvenated? What is the ultimate test of leadership? Is it authenticity? Here with me to discuss this is Janan Ganesh and you made a quite extraordinary attack this week on authenticity and a putative challenger to Mrs. May, Jacob Rees-Mogg.\n\nYeah, authenticity has become the gold dust when looking for political candidates in the modern world. Jeremy Corbyn is seen to have done well as labour leader because he has authenticity. Boris Johnson for a long time looked like a plausible prime minister because people said, well, he's authentic. He's unspun. But I think him Jacob Rees-Mogg you have an example of someone who's clearly authentic, doesn't disguise the fact that he's a very privileged man, and doesn't disguise the fact that he's--\n\nSome of the times editor.\n\nFormer newspaper editor.\n\nWilliam Rees-Mogg.\n\nBut doesn't also disguise the fact that he's a committed Catholic. And he expressed views on abortion and same-sex marriage that annoyed a lot of people who were big fans of him only two weeks ago. And that's an example of the fact that when people say they want authenticity, what they mean is the kind of authenticity they like.\n\nYeah but--\n\nThere's good authenticity and then there's the bad stuff, which they suddenly go cold over.\n\nYeah, but Janan, I mean, we watched the British election campaign earlier this year in which Theresa May, for all her qualities, was incapable of spontaneous talking, speaking on the trail. And she wasn't authentic.\n\nShe could argue that that was the authentic her, that she's not a natural public performer. She's not a natural people person. Actually she's a diligent, behind-the-scenes kind of politician who works through a brief and does her best in that way, rather than a spectacular personality. But that's fine. The problem I have with the authenticity cult is that people think it's somehow enough. That if someone is expressive of views that are unusual, doesn't employ a media adviser, it's very direct--\n\nThat's the point about media advisers. I mean, you know, I've covered American presidential campaigns. I mean, they're all over the place. You get the blow dried hair cut candidate.\n\nYeah.\n\nAnd he's totally scripted or she's totally scripted. Look at Hillary Clinton last year.\n\nAnd that's annoying to a lot of people and hard to connect with. But in office, is it enough to say, well, I'm authentic and, therefore, I should be national leader of a country of 60 million people with nuclear weapons and a very large economy. I think authenticity is not even necessary, let alone sufficient. And we started to talk about it as though it was almost a sufficient criterion on which to elect a national leader.\n\nWell, I'm coming round to your point of view. But what about Jeremy Corbyn? I mean, isn't he authentic? I mean, the flat cap, the beard has been trimmed now, of course.\n\nA bit, yeah.\n\nBut you know, he is what he looks like, which is a 1970s style socialist.\n\nCompletely, I think he's entirely authentic. Hasn't changed his views since he entered parliament in the early 1980s, completely unspun, slight trimming of the beard. I think he started to wear a suit now, or at least a jacket and tie but nothing artificial really. But is that a sufficient criterion on which to elect a national leader? And my only--\n\nSo what are the qualities that we need? And if we're going to put authenticity slightly to the side, not completely--\n\nYeah.\n\nWhat are we looking at?\n\nI think that-- I still think a good national leader will, to a large extent, be inauthentic. And we will find them objectionable in many ways. And so someone like a Tony Blair or a John Major was seen to be sometimes underhand to not say the entirety of what they mean. And that's necessary. You're having to balance interests within your cabinet. You're having to balance principle with practical reality. You're having to set this interest group up against that one and somehow keep some semblance of popularity while governing the country.\n\nYou can only do that as a national leader if you are a little bit sly, a little bit inauthentic, and are willing to not say absolutely everything you mean at any given time. So I think it's almost kind of weirdly juvenile demand that we, as the media, and to a certain extent the electorate have come up with in expecting everyone to be completely honest and authentic all the time.\n\nSo I'm writing down Jacob Rees-Mogg's chances of being the next Conservative Party leader. Thank you Janan Ganesh.\n\nThank you.",
         "url": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
-        "mainImage": {
-            "title": "VIDEO_MAS-OPINION_ReesMogg_LionelJanan.jpg",
-            "description": "",
-            "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
-            "width": 2048,
-            "height": 1152,
-            "ratio": 1.7777777777777777,
-            "aspectRatio": 0.5625
-        },
         "attachments": [
             {
                 "url": "https://next-media-api.ft.com/renditions/15053217972320/640x360.mp4",
@@ -667,43 +1108,17 @@
                 "url": "https://next-media-api.ft.com/captions/15053217972320.vtt"
             }
         ],
-        "containedIn": [ ],
         "relativeUrl": "/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+        "mainImage": {
+            "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
+            "title": "VIDEO_MAS-OPINION_ReesMogg_LionelJanan.jpg",
+            "description": "",
+            "width": 2048,
+            "height": 1152,
+            "ratio": 1.77778,
+            "aspectRatio": 0.5625
+        },
         "annotations": [
-            {
-                "apiUrl": "http://api.ft.com/things/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "directType": "http://www.ft.com/ontology/Genre",
-                "id": "e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Comment",
-                "type": "GENRE",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Genre"
-                ],
-                "url": "https://www.ft.com/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05",
-                "preposition": "",
-                "relativeUrl": "/stream/e569e23b-0c3e-3d20-8ed0-4c17b8177c05"
-            },
-            {
-                "apiUrl": "http://api.ft.com/things/38dbd827-fedc-3ebe-919f-e64cf55ea959",
-                "directType": "http://www.ft.com/ontology/Section",
-                "id": "38dbd827-fedc-3ebe-919f-e64cf55ea959",
-                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-                "prefLabel": "Opinion",
-                "type": "SECTION",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/classification/Classification",
-                    "http://www.ft.com/ontology/Section"
-                ],
-                "url": "https://www.ft.com/opinion",
-                "preposition": "in",
-                "relativeUrl": "/opinion"
-            },
             {
                 "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
                 "directType": "http://www.ft.com/ontology/product/Brand",
@@ -717,36 +1132,31 @@
                     "http://www.ft.com/ontology/classification/Classification",
                     "http://www.ft.com/ontology/product/Brand"
                 ],
-                "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
                 "preposition": "from",
+                "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
                 "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
             },
             {
-                "apiUrl": "http://api.ft.com/people/a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-                "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-                "prefLabel": "Janan Ganesh",
-                "type": "PERSON",
+                "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+                "directType": "http://www.ft.com/ontology/Genre",
+                "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "Opinion",
+                "type": "GENRE",
                 "types": [
                     "http://www.ft.com/ontology/core/Thing",
                     "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/person/Person"
+                    "http://www.ft.com/ontology/classification/Classification",
+                    "http://www.ft.com/ontology/Genre"
                 ],
-                "url": "https://www.ft.com/comment/columnists/janan-ganesh",
-                "preposition": "from",
-                "relativeUrl": "/comment/columnists/janan-ganesh",
-                "attributes": [
-                    {
-                        "key": "headshot",
-                        "value": "fthead:janan-ganesh"
-                    }
-                ]
+                "preposition": "",
+                "url": "https://www.ft.com/opinion",
+                "relativeUrl": "/opinion"
             },
             {
-                "apiUrl": "http://api.ft.com/people/7fce0429-54de-31d5-b511-acc9c4914eb2",
+                "apiUrl": "http://api.ft.com/people/08c3aeaf-259b-436a-83d9-7253c78540fc",
                 "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "7fce0429-54de-31d5-b511-acc9c4914eb2",
+                "id": "08c3aeaf-259b-436a-83d9-7253c78540fc",
                 "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
                 "prefLabel": "Lionel Barber",
                 "type": "PERSON",
@@ -755,34 +1165,56 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/lionel-barber",
                 "preposition": "from",
-                "relativeUrl": "/lionel-barber",
                 "attributes": [
                     {
                         "key": "headshot",
-                        "value": "fthead:lionel-barber"
+                        "value": "fthead-v1:lionel-barber"
                     }
-                ]
+                ],
+                "url": "https://www.ft.com/lionel-barber",
+                "relativeUrl": "/lionel-barber"
+            },
+            {
+                "apiUrl": "http://api.ft.com/people/b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+                "directType": "http://www.ft.com/ontology/person/Person",
+                "id": "b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Janan Ganesh",
+                "type": "PERSON",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/person/Person"
+                ],
+                "preposition": "from",
+                "attributes": [
+                    {
+                        "key": "headshot",
+                        "value": "fthead-v1:janan-ganesh"
+                    }
+                ],
+                "url": "https://www.ft.com/janan-ganesh",
+                "relativeUrl": "/janan-ganesh"
             }
         ],
-        "displayConcept": {
-            "apiUrl": "http://api.ft.com/things/38dbd827-fedc-3ebe-919f-e64cf55ea959",
-            "directType": "http://www.ft.com/ontology/Section",
-            "id": "38dbd827-fedc-3ebe-919f-e64cf55ea959",
+        "genreConcept": {
+            "apiUrl": "http://api.ft.com/things/6da31a37-691f-4908-896f-2829ebe2309e",
+            "directType": "http://www.ft.com/ontology/Genre",
+            "id": "6da31a37-691f-4908-896f-2829ebe2309e",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
             "prefLabel": "Opinion",
-            "type": "SECTION",
+            "type": "GENRE",
             "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
                 "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
+                "http://www.ft.com/ontology/Genre"
             ],
+            "preposition": "",
             "url": "https://www.ft.com/opinion",
-            "preposition": "in",
             "relativeUrl": "/opinion"
         },
-        "genreConcept": null,
         "brandConcept": {
             "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
             "directType": "http://www.ft.com/ontology/product/Brand",
@@ -796,37 +1228,15 @@
                 "http://www.ft.com/ontology/classification/Classification",
                 "http://www.ft.com/ontology/product/Brand"
             ],
-            "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
             "preposition": "from",
+            "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
             "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
         },
         "authorConcepts": [
             {
-                "apiUrl": "http://api.ft.com/people/a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
+                "apiUrl": "http://api.ft.com/people/08c3aeaf-259b-436a-83d9-7253c78540fc",
                 "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "a026ef35-c5d3-3fd4-8646-5e1dc1606a9a",
-                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-                "prefLabel": "Janan Ganesh",
-                "type": "PERSON",
-                "types": [
-                    "http://www.ft.com/ontology/core/Thing",
-                    "http://www.ft.com/ontology/concept/Concept",
-                    "http://www.ft.com/ontology/person/Person"
-                ],
-                "url": "https://www.ft.com/comment/columnists/janan-ganesh",
-                "preposition": "from",
-                "relativeUrl": "/comment/columnists/janan-ganesh",
-                "attributes": [
-                    {
-                        "key": "headshot",
-                        "value": "fthead:janan-ganesh"
-                    }
-                ]
-            },
-            {
-                "apiUrl": "http://api.ft.com/people/7fce0429-54de-31d5-b511-acc9c4914eb2",
-                "directType": "http://www.ft.com/ontology/person/Person",
-                "id": "7fce0429-54de-31d5-b511-acc9c4914eb2",
+                "id": "08c3aeaf-259b-436a-83d9-7253c78540fc",
                 "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
                 "prefLabel": "Lionel Barber",
                 "type": "PERSON",
@@ -835,17 +1245,104 @@
                     "http://www.ft.com/ontology/concept/Concept",
                     "http://www.ft.com/ontology/person/Person"
                 ],
-                "url": "https://www.ft.com/lionel-barber",
                 "preposition": "from",
-                "relativeUrl": "/lionel-barber",
                 "attributes": [
                     {
                         "key": "headshot",
-                        "value": "fthead:lionel-barber"
+                        "value": "fthead-v1:lionel-barber"
                     }
-                ]
+                ],
+                "url": "https://www.ft.com/lionel-barber",
+                "relativeUrl": "/lionel-barber"
+            },
+            {
+                "apiUrl": "http://api.ft.com/people/b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+                "directType": "http://www.ft.com/ontology/person/Person",
+                "id": "b1d025bc-56d5-4420-ae8c-49c0c02cc816",
+                "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+                "prefLabel": "Janan Ganesh",
+                "type": "PERSON",
+                "types": [
+                    "http://www.ft.com/ontology/core/Thing",
+                    "http://www.ft.com/ontology/concept/Concept",
+                    "http://www.ft.com/ontology/person/Person"
+                ],
+                "preposition": "from",
+                "attributes": [
+                    {
+                        "key": "headshot",
+                        "value": "fthead-v1:janan-ganesh"
+                    }
+                ],
+                "url": "https://www.ft.com/janan-ganesh",
+                "relativeUrl": "/janan-ganesh"
             }
-        ]
+        ],
+        "design": {
+            "theme": "basic",
+            "layout": "default"
+        },
+        "displayConcept": {
+            "apiUrl": "http://api.ft.com/brands/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+            "directType": "http://www.ft.com/ontology/product/Brand",
+            "id": "6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+            "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+            "prefLabel": "FT World video",
+            "type": "BRAND",
+            "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/classification/Classification",
+                "http://www.ft.com/ontology/product/Brand"
+            ],
+            "preposition": "from",
+            "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+            "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+            "isDisplayTag": false
+        },
+        "teaser": {
+            "id": "a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+            "url": "https://www.ft.com/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+            "relativeUrl": "/video/a1af0574-eafb-41bd-aa4f-59aa2cd084c2",
+            "type": "video",
+            "indicators": {
+                "isColumn": false,
+                "isOpinion": true,
+                "isScoop": false,
+                "isExclusive": false,
+                "isEditorsChoice": false,
+                "accessLevel": "subscribed"
+            },
+            "metaPrefixText": "FT World video",
+            "metaSuffixText": "5 min",
+            "metaLink": {
+                "id": "6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+                "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+                "prefLabel": "FT World video",
+                "type": "BRAND",
+                "url": "https://www.ft.com/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613",
+                "relativeUrl": "/stream/6d0d2fab-102e-32f8-bd3b-f2a12c454613"
+            },
+            "metaAltLink": null,
+            "title": "Is being authentic enough to be a leader?",
+            "standfirst": "The FT's editor and our chief political commentator on authenticity in politics",
+            "altStandfirst": null,
+            "publishedDate": "2017-09-13T17:10:52.586Z",
+            "firstPublishedDate": "2017-09-13T17:10:52.586Z",
+            "image": {
+                "url": "http://prod-upp-image-read.ft.com/3cf28f7f-78ff-4c1f-a197-896dea2a9595",
+                "width": 2048,
+                "height": 1152
+            },
+            "video": {
+                "url": "https://next-media-api.ft.com/renditions/15053217972320/640x360.mp4",
+                "width": 640,
+                "height": 360,
+                "duration": 281513,
+                "codec": "h264",
+                "mediaType": "video/mp4"
+            }
+        }
     },
     {
         "id": "98b46b5f-17d3-40c2-8eaa-082df70c5f01",
@@ -857,11 +1354,11 @@
         "byline": "Alphachat is the conversational podcast about business and economics produced by the Financial Times in New York. Each week, FT hosts and guests delve into a new theme, with more wonkiness, humour and irreverence than you'll find anywhere else",
         "publishedDate": "2017-09-15T04:01:00.000Z",
         "firstPublishedDate": "2017-09-15T04:01:00.000Z",
-        "curatedRelatedContent": [ ],
+        "curatedRelatedContent": [],
         "comments": {
             "enabled": false
         },
-        "standout": { },
+        "standout": {},
         "realtime": false,
         "originatingParty": "FT",
         "_lastUpdatedDateTime": "2017-09-15T12:24:47.138Z",
@@ -979,7 +1476,7 @@
             "preposition": "from",
             "relativeUrl": "/stream/dee66cf5-5374-4674-9f70-90cccbc9604a"
         },
-        "authorConcepts": [ ],
+        "authorConcepts": [],
         "mainImage": {
             "title": "Logo for FT Alphachat podcast",
             "description": "",
@@ -1000,11 +1497,11 @@
         "byline": "Each month FT music critics and contributors discuss the story of a song, from its origins and early recordings through cover versions good and bad. Formerly called FT Arts.",
         "publishedDate": "2017-09-15T04:00:00.000Z",
         "firstPublishedDate": "2017-09-15T04:00:00.000Z",
-        "curatedRelatedContent": [ ],
+        "curatedRelatedContent": [],
         "comments": {
             "enabled": false
         },
-        "standout": { },
+        "standout": {},
         "realtime": false,
         "originatingParty": "FT",
         "_lastUpdatedDateTime": "2017-09-15T08:34:15.874Z",
@@ -1122,7 +1619,7 @@
             "preposition": "from",
             "relativeUrl": "/stream/1d3f86a4-4df8-3652-adfc-dcae9e6645a5"
         },
-        "authorConcepts": [ ],
+        "authorConcepts": [],
         "mainImage": {
             "title": "Logo for FT Life of a Song podcast",
             "description": "",

--- a/test/fixtures/content/items.json
+++ b/test/fixtures/content/items.json
@@ -537,7 +537,7 @@
         "containedIn": [],
         "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
-        "canAllGraphicsBeSyndicated": null,
+        "canAllGraphicsBeSyndicated": false,
         "hasGraphics": false,
         "comments": {
             "enabled": true

--- a/test/fixtures/content/items.json
+++ b/test/fixtures/content/items.json
@@ -19,6 +19,8 @@
         "containedIn": [],
         "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
+        "canAllGraphicsBeSyndicated": false,
+        "hasGraphics": true,
         "comments": {
             "enabled": true
         },
@@ -535,6 +537,8 @@
         "containedIn": [],
         "canBeDistributed": "yes",
         "canBeSyndicated": "yes",
+        "canAllGraphicsBeSyndicated": null,
+        "hasGraphics": false,
         "comments": {
             "enabled": true
         },

--- a/test/server/controllers/resolve.spec.js
+++ b/test/server/controllers/resolve.spec.js
@@ -247,7 +247,7 @@ describe(MODULE_ID, function () {
 			id: '42ad255a-99f9-11e7-b83c-9588e51488a0',
 			lang: 'en',
 			messageCode: 'MSG_2100',
-			publishedDate: '2017-09-15T10:38:16.000Z',
+			publishedDate: '2017-09-15T15:48:53.000Z',
 			publishedDateDisplay: '15th Sep 2017',
 			saved: false,
 			title: 'Pound leaps to highest level since Brexit vote',

--- a/test/server/controllers/resolve.spec.js
+++ b/test/server/controllers/resolve.spec.js
@@ -240,10 +240,12 @@ describe(MODULE_ID, function () {
 		await underTest(req, res, () => {});
 
 		expect(res.json).to.have.been.calledWith([{
+			canAllGraphicsBeSyndicated: false,
 			canBeSyndicated: 'yes',
 			canDownload: 1,
 			downloaded: true,
 			embargoPeriod: null,
+			hasGraphics: true,
 			id: '42ad255a-99f9-11e7-b83c-9588e51488a0',
 			lang: 'en',
 			messageCode: 'MSG_2100',
@@ -254,10 +256,12 @@ describe(MODULE_ID, function () {
 			type: 'article',
 			wordCount: undefined
 		}, {
+			canAllGraphicsBeSyndicated: null,
 			canBeSyndicated: 'yes',
 			canDownload: 1,
 			downloaded: true,
 			embargoPeriod: null,
+			hasGraphics: false,
 			id: 'ef4c49fe-980e-11e7-b83c-9588e51488a0',
 			lang: 'en',
 			messageCode: 'MSG_2100',

--- a/test/server/controllers/resolve.spec.js
+++ b/test/server/controllers/resolve.spec.js
@@ -256,7 +256,7 @@ describe(MODULE_ID, function () {
 			type: 'article',
 			wordCount: undefined
 		}, {
-			canAllGraphicsBeSyndicated: null,
+			canAllGraphicsBeSyndicated: false,
 			canBeSyndicated: 'yes',
 			canDownload: 1,
 			downloaded: true,

--- a/test/server/lib/enrich/article.js
+++ b/test/server/lib/enrich/article.js
@@ -59,6 +59,14 @@ describe(MODULE_ID, function () {
 			it('bodyHTML__PLAIN', function() {
 				expect(item.bodyHTML__PLAIN).to.be.a('string');
 			});
+
+			it('hasGraphics', function() {
+				expect(item.hasGraphics).to.be.a('boolean');
+			});
+
+			it('canAllGraphicsBeSyndicated', function() {
+				expect(item.canAllGraphicsBeSyndicated).to.be.a('boolean');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Ticket
https://financialtimes.atlassian.net/browse/ACC-622

## Things done in this PR
- updated some fixtures to their 2020 state (fixtures are used for mocks in tests and have been stuck in their 2017 version). Not all of the fixtures have been updated (see #234 ) because it was out of scope for this ticket. 
- the endpoint now returns `hasGraphics` boolean and `canAllGraphicsBeSyndicated` boolean *for article only*

## Shortfalls
Currently we don't have an article that has `canAllGraphicsBeSyndicated` `true`, and I'm not sure what's the practicality of having a test for something that is different in prod. 