### PR TITLE
fix: Inc 697 - Syndication users unable to download paid for content

### DIFF
--- a/server/controllers/download-by-content-id.js
+++ b/server/controllers/download-by-content-id.js
@@ -38,7 +38,7 @@ module.exports = exports = async (req, res, next) => {
 		return;
 	}
 
-	if(isDownloadDisabled(content, user)){
+	if(isDownloadDisabled(content, contract)){
 		res.sendStatus(403);
 		return;
 	}

--- a/server/helpers/is-download-disabled.js
+++ b/server/helpers/is-download-disabled.js
@@ -1,11 +1,11 @@
 'use strict';
 
-module.exports = exports  = (item, user) => {
+module.exports = exports  = (item, contract) => {
 	return [
 		item.type === 'package',
 		item.notAvailable === true,
 		item.canBeSyndicated === 'verify',
-		item.canBeSyndicated === 'withContributorPayment' && user.contributor_content !== true,
+		item.canBeSyndicated === 'withContributorPayment' && contract.contributor_content !== true,
 		item.canBeSyndicated === 'no',
 		!item.canBeSyndicated,
 		item.canDownload < 1

--- a/test/server/helpers/is-download-disabled.spec.js
+++ b/test/server/helpers/is-download-disabled.spec.js
@@ -12,45 +12,45 @@ const MODULE_ID =
 
 describe(MODULE_ID, function () {
 	let item;
-	let user = {};
+	let contract = {};
 	it('returns true if item type is package', function () {
 		item = {
 			type: 'package',
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
 	it('returns true if item is not avaliable', function () {
 		item = {
 			notAvailable: true,
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
 	it('returns true if item canBeSyndicated is verify', function () {
 		item = {
 			canBeSyndicated: 'verify',
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
-	it('returns true if item.canBeSyndicated is withContributorPayment and user.contributor_content is not true', function () {
+	it('returns true if item.canBeSyndicated is withContributorPayment and contract.contributor_content is not true', function () {
 		item = {
 			canBeSyndicated: 'withContributorPayment',
 		};
-		user = {
+		contract = {
 			contributor_content: false,
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
 	it('returns true if item canBeSyndicated is no', function () {
 		item = {
 			canBeSyndicated: 'no',
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
 	it('returns true if item canDownload is less than 1', function () {
 		item = {
 			canDownload: 0,
 		};
-		expect(isDownloadDisabled(item, user)).to.be.true;
+		expect(isDownloadDisabled(item, contract)).to.be.true;
 	});
 	it('returns false if item type is article, is avaliable, can be syndicated and can be downloaded', function () {
 		item = {
@@ -59,6 +59,6 @@ describe(MODULE_ID, function () {
 			canBeSyndicated: 'yes',
 			canDownload: 2,
 		};
-		expect(isDownloadDisabled(item, user)).to.be.false;
+		expect(isDownloadDisabled(item, contract)).to.be.false;
 	});
 });


### PR DESCRIPTION
Users with a licence that can download paid content should have contributor_content as true.

However, contributor_content should have be gotten from res.local.contract that is defined [here](https://github.com/Financial-Times/next-syndication-api/blob/master/server/middleware/get-contract-by-id-from-param.js#L12) not res.local.user.