### PR TITLE
chore: Bump version to 0.33.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",


### PR DESCRIPTION
This PR bumps syndication-api to version 0.33.2