### PR TITLE
NOPS-431 Fix bug causing syndication icons to go missing

### DIFF
--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -37,7 +37,13 @@ module.exports = exports = function article(content, format) {
 	// We are assuming that canBeSyndicated is the same for all sizes of a picture
 	// We are asking if ALL Graphics can be syndicated, which means as long as at least one item
 	// can't be, the answer to this is 'no'
-	const atLeastOneGraphicCantBeShared = content.embeds && content.embeds.filter(embed => embed && embed.type.endsWith('Graphic')).some(item => item.canBeSyndicated !== 'yes');
+	const atLeastOneGraphicCantBeShared =
+		content.embeds &&
+		content.embeds
+			.filter(
+				(embed) => embed && embed.type && embed.type.endsWith("Graphic")
+			)
+			.some((item) => item.canBeSyndicated !== "yes");
 
 	content.canAllGraphicsBeSyndicated = !atLeastOneGraphicCantBeShared;
 


### PR DESCRIPTION
It was reported to Ops Cop that the syndication icons are missing from
the front page only. We narrowed down the cause to this error:
`Cannot read property 'endsWith' of undefined`. As a fix, we now check
if both `embed` and `embed.type` exist before doing any additional
checks.