### PR TITLE
ACC-558 Added spike health check for syndication-dl

### DIFF
--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -1,31 +1,21 @@
 const nHealth = require('n-health');
 const samplePeriod = 10; // minutes
+const threshold = 5;
 
 // 3 and 5 are the positions of wildcards in the chain, 0 based
 // 6 is the node the count is based on, 0 based
-const metric403 = 'aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.403.count, 3, 5), 6)';
-const metric404 = 'aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.404.count, 3, 5), 6)';
-
+const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.* _{ GET, POST, PUT }.res.status_5xx.count, 3, 5), 6)';
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
-const services = [
-	{
-		id: 'syndication-download-403-forbidden-spike',
-		metric: metric403,
-		threshold: 1,
-		name: '403 rate for next-syndication-dl is acceptable',
-		businessImpact: 'Syndication users are experiencing issues downloading articles',
-		technicalSummary: `The count of 403 (Forbidden) responses for syndication download requests across all heroku dynos is higher than a threshold of 1 over the last ${samplePeriod} minutes`,
-	},
-	{
-		id: 'syndication-download-404-not-found-spike',
-		metric: metric404,
-		threshold: 5,
-		name: '404 rate for next-syndication-dl is acceptable',
-		businessImpact: 'Syndication users are experiencing issues downloading articles',
-		technicalSummary: `The count of 404 (Not Found) responses for syndication download requests across all heroku dynos is higher than a threshold of 5 over the last ${samplePeriod} minutes`,
-	}
-
-]
-
-module.exports = services.map(service => nHealth.runCheck(Object.assign({}, service, {panicGuide, severity: 1, samplePeriod: `${samplePeriod}min`, type: 'graphiteThreshold'})))
+module.exports = nHealth.runCheck({
+	id: 'syndication-download-4xx-spike',
+	metric,
+	threshold,
+	name: '4xx rate for next-syndication-dl is acceptable',
+	businessImpact: 'Syndication may be experiencing issues downloading articles',
+	technicalSummary: `The count of 4xx responses for syndication download requests across all heroku dynos is higher than a threshold of ${threshold} over the last ${samplePeriod} minutes`,
+	panicGuide,
+	severity: 1, 
+	samplePeriod: `${samplePeriod}min`, 
+	type: 'graphiteThreshold'
+});

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -4,7 +4,7 @@ const threshold = 5;
 
 // 3 and 5 are the positions of wildcards in the chain, 0 based
 // 6 is the node the count is based on, 0 based
-const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.* _{ GET, POST, PUT }.res.status_4xx.count, 3, 5), 6)';
+const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.*.res.status.4xx.count, 3, 5), 6)';
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
 module.exports = nHealth.runCheck({

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -2,9 +2,7 @@ const nHealth = require('n-health');
 const samplePeriod = 30; // minutes
 const threshold = 5;
 
-// 3 and 5 are the positions of wildcards in the chain, 0 based
-// 6 is the node the count is based on, 0 based
-const metric = `summarize(sumSeries(next.heroku.syndication-dl.*.express.*.res.status.*.count), "${samplePeriod}min", "sum", true)`;
+const metric = `summarize(sumSeries(next.heroku.syndication-dl.*.express.*.res.status.4*.count), "${samplePeriod}min", "sum", true)`;
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
 module.exports = nHealth.runCheck({

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -3,26 +3,26 @@ const samplePeriod = 10; // minutes
 
 // 3 and 5 are the positions of wildcards in the chain, 0 based
 // 6 is the node the count is based on, 0 based
-const metric403 = aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.403.count, 3, 5), 6);
-const metric404 = aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.404.count, 3, 5), 6);
+const metric403 = 'aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.403.count, 3, 5), 6)';
+const metric404 = 'aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.404.count, 3, 5), 6)';
 
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
 const services = [
 	{
-		id: 'syndication-download-403-forbidden-spike'
+		id: 'syndication-download-403-forbidden-spike',
 		metric: metric403,
 		threshold: 1,
-		name: `403 rate for next-syndication-dl is acceptable`,
-		businessImpact: `Syndication users are experiencing issues downloading articles`,
+		name: '403 rate for next-syndication-dl is acceptable',
+		businessImpact: 'Syndication users are experiencing issues downloading articles',
 		technicalSummary: `The count of 403 (Forbidden) responses for syndication download requests across all heroku dynos is higher than a threshold of 1 over the last ${samplePeriod} minutes`,
 	},
 	{
-		id: 'syndication-download-404-not-found-spike'
+		id: 'syndication-download-404-not-found-spike',
 		metric: metric404,
 		threshold: 5,
-		name: `404 rate for next-syndication-dl is acceptable`,
-		businessImpact: `Syndication users are experiencing issues downloading articles`,
+		name: '404 rate for next-syndication-dl is acceptable',
+		businessImpact: 'Syndication users are experiencing issues downloading articles',
 		technicalSummary: `The count of 404 (Not Found) responses for syndication download requests across all heroku dynos is higher than a threshold of 5 over the last ${samplePeriod} minutes`,
 	}
 

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -15,7 +15,7 @@ module.exports = nHealth.runCheck({
 	businessImpact: 'Syndication may be experiencing issues downloading articles',
 	technicalSummary: `The count of 4xx responses for syndication download requests across all heroku dynos is higher than a threshold of ${threshold} over the last ${samplePeriod} minutes`,
 	panicGuide,
-	severity: 1, 
-	samplePeriod: `${samplePeriod}min`, 
+	severity: 1,
+	samplePeriod: `${samplePeriod}min`,
 	type: 'graphiteThreshold'
 });

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -1,0 +1,31 @@
+const nHealth = require('n-health');
+const samplePeriod = 10; // minutes
+
+// 3 and 5 are the positions of wildcards in the chain, 0 based
+// 6 is the node the count is based on, 0 based
+const metric403 = aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.403.count, 3, 5), 6);
+const metric404 = aliasByNode(sumSeriesWithWildcards(next.heroku.$app.*.express.* _{ GET, POST, PUT }.res.status.404.count, 3, 5), 6);
+
+const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
+
+const services = [
+	{
+		id: 'syndication-download-403-forbidden-spike'
+		metric: metric403,
+		threshold: 1,
+		name: `403 rate for next-syndication-dl is acceptable`,
+		businessImpact: `Syndication users are experiencing issues downloading articles`,
+		technicalSummary: `The count of 403 (Forbidden) responses for syndication download requests across all heroku dynos is higher than a threshold of 1 over the last ${samplePeriod} minutes`,
+	},
+	{
+		id: 'syndication-download-404-not-found-spike'
+		metric: metric404,
+		threshold: 5,
+		name: `404 rate for next-syndication-dl is acceptable`,
+		businessImpact: `Syndication users are experiencing issues downloading articles`,
+		technicalSummary: `The count of 404 (Not Found) responses for syndication download requests across all heroku dynos is higher than a threshold of 5 over the last ${samplePeriod} minutes`,
+	}
+
+]
+
+module.exports = services.map(service => nHealth.runCheck(Object.assign({}, service, {panicGuide, severity: 1, samplePeriod: `${samplePeriod}min`, type: 'graphiteThreshold'})))

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -4,7 +4,7 @@ const threshold = 5;
 
 // 3 and 5 are the positions of wildcards in the chain, 0 based
 // 6 is the node the count is based on, 0 based
-const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.* _{ GET, POST, PUT }.res.status_5xx.count, 3, 5), 6)';
+const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.* _{ GET, POST, PUT }.res.status_4xx.count, 3, 5), 6)';
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
 module.exports = nHealth.runCheck({

--- a/health/dl-error-spikes.js
+++ b/health/dl-error-spikes.js
@@ -1,10 +1,10 @@
 const nHealth = require('n-health');
-const samplePeriod = 10; // minutes
+const samplePeriod = 30; // minutes
 const threshold = 5;
 
 // 3 and 5 are the positions of wildcards in the chain, 0 based
 // 6 is the node the count is based on, 0 based
-const metric = 'aliasByNode(sumSeriesWithWildcards(next.heroku.syndication-dl.*.express.*.res.status.4xx.count, 3, 5), 6)';
+const metric = `summarize(sumSeries(next.heroku.syndication-dl.*.express.*.res.status.*.count), "${samplePeriod}min", "sum", true)`;
 const panicGuide = 'Check the heroku logs for the app for any error messages (`heroku logs --app ft-next-syndication-dl --tail --num 100` - num being the number of lines to retrieve)'
 
 module.exports = nHealth.runCheck({

--- a/server/app-dl.js
+++ b/server/app-dl.js
@@ -27,7 +27,10 @@ const app = module.exports = express({
 	systemCode: 'next-syndication-dl',
 	graphiteName: 'syndication-dl',
 	withBackendAuthentication: false,
-	withFlags: true
+	withFlags: true,
+	healthchecks: [
+		require('../health/dl-error-spikes'),
+	]
 });
 
 const middleware = [


### PR DESCRIPTION
Currently next-syndication-dl doesn't have any healthchecks, so we are not alerted about any spikes in 404s (which are the symptoms of issues such as this one). This healtcheck will help to spot issues ourselves rather than waiting on Customer Care to report this from users.

**Why is this not a "number of successes vs number of failures"?** The number of `200` responses isn't high enough on regular basis for the ratio to be a sensible measure.  

Reasoning for numbers:
severity - 1 - in the incident linked above it was stated that it ended up being a P2 but it should really have been a P1
threshold for 404 - 5 - it feels like 2 or 3 can happen organically every now and again, but anything over 5 would benefit from at least a glance what's happening
threshold for 403 - 1 - not sure about this one, we rarely get any (we had total of 2 last week, 3 in the past 30 days).