### PR TITLE
chore: release next-syndication-api v0.34.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "1.8.0",


### PR DESCRIPTION
This PR prepares next-syndication-api for `v0.34.2` release