### PR TITLE
Use a fixed string for source name

### DIFF
--- a/health/sqs.js
+++ b/health/sqs.js
@@ -23,7 +23,7 @@ const writeFileAsync = util.promisify(writeFile);
 const BLOATED_THRESHOLD = HEALTH_CHECK_HISTORY.bloated_threshold;
 
 const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
-const log = new Logger({source: MODULE_ID});
+const log = new Logger({source: 'health/sqs'});
 
 const HISTORY_DIRECTORY = path.resolve(HEALTH_CHECK_HISTORY.directory, 'sqs');
 
@@ -122,7 +122,7 @@ module.exports = exports = new (class SQSCheck extends nHealthCheck {
 
 		this.status = ok === true ? nHealthStatus.PASSED : nHealthStatus.FAILED;
 
-		log.info(`${MODULE_ID} in ${Date.now() - START}ms => ${this.checkOutput}`);
+		log.info('start', {event: `${MODULE_ID} in ${Date.now() - START}ms => ${this.checkOutput}`});
 
 		return this.checkOutput;
 	}

--- a/health/sqs.js
+++ b/health/sqs.js
@@ -122,7 +122,7 @@ module.exports = exports = new (class SQSCheck extends nHealthCheck {
 
 		this.status = ok === true ? nHealthStatus.PASSED : nHealthStatus.FAILED;
 
-		log.info('start', {event: `${MODULE_ID} in ${Date.now() - START}ms => ${this.checkOutput}`});
+		log.info('sqsHealthCheckCompleted', {message: `${MODULE_ID} in ${Date.now() - START}ms => ${this.checkOutput}`});
 
 		return this.checkOutput;
 	}

--- a/health/sqs.js
+++ b/health/sqs.js
@@ -23,7 +23,7 @@ const writeFileAsync = util.promisify(writeFile);
 const BLOATED_THRESHOLD = HEALTH_CHECK_HISTORY.bloated_threshold;
 
 const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
-const log = new Logger({source: 'health/sqs'});
+const log = new Logger({source: MODULE_ID});
 
 const HISTORY_DIRECTORY = path.resolve(HEALTH_CHECK_HISTORY.directory, 'sqs');
 


### PR DESCRIPTION
There were errors regarding *Graphite Filename too long Alert *

Links: https://financialtimes.splunkcloud.com/en-US/app/search/search?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2FGraphite%2520Filename%2520too%2520long%2520Alert&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&q=search%20index%3Dapp_prod%20source%3D%22%2Fvar%2Flog%2Fgo-carbon%2Fgo-carbon.log%22%20%22ERROR%20%5Bpersister%5D%20failed%20to%20open%20whisper%20file%22%20%20%7C%20rex%20%22%5C%22path%5C%22%3A%20%5C%22%5C%2Fopt%5C%2Fgraphite%5C%2Fstorage%5C%2Fwhisper(%3F%3Cpath%3E%5C%2F%5B%5Cw%5C-%5D%2B%5C%2F%5B%5Cw%5C-%5D%2B%5C%2F%5B%5Cw%5C-%5D%2B)%22&earliest=-1h&latest=now&sid=1603969504.2367540

![Screen Shot 2020-10-29 at 11 35 03](https://user-images.githubusercontent.com/56944/97563375-db6f4700-19da-11eb-8ef8-7ab535289fb1.png)

The issue seems to be related to `health_sqs` 