### PR TITLE
ACC-754 fixed evil JS idiosyncrasy 

### DIFF
--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -39,8 +39,8 @@ module.exports = exports = function article(content, contract, graphicSyndicatio
 			)
 
 	content.canAllGraphicsBeSyndicated =
-		// From MDN docs: every acts like the "for all" quantifier in mathematics. 
-		// In particular, for an empty array, it returns true. 
+		// From MDN docs: every acts like the "for all" quantifier in mathematics.
+		// In particular, for an empty array, it returns true.
 		// So if the filter above returned an empty array, [].every(whatever) would return `true`
 		graphicEmbeds.length > 0 &&
 		graphicEmbeds

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -39,7 +39,10 @@ module.exports = exports = function article(content, contract, graphicSyndicatio
 			)
 
 	content.canAllGraphicsBeSyndicated =
-		graphicEmbeds &&
+		// From MDN docs: every acts like the "for all" quantifier in mathematics. 
+		// In particular, for an empty array, it returns true. 
+		// So if the filter above returned an empty array, [].every(whatever) would return `true`
+		graphicEmbeds.length > 0 &&
 		graphicEmbeds
 			.every((item) => item.canBeSyndicated === 'yes');
 
@@ -58,7 +61,7 @@ module.exports = exports = function article(content, contract, graphicSyndicatio
 			.removeElementsByTagName()
 			.removeProprietaryElement();
 
-		if (graphicSyndicationFlag && content.extension  === 'docx' && contract.allowed.rich_articles){
+		if (graphicSyndicationFlag && content.extension === 'docx' && contract.allowed.rich_articles) {
 			documentBuilder.removeNonSyndicatableImages();
 		} else {
 			documentBuilder.removeElementsByTagName(['img', 'figure']);

--- a/server/lib/enrich/article.js
+++ b/server/lib/enrich/article.js
@@ -42,6 +42,7 @@ module.exports = exports = function article(content, contract, graphicSyndicatio
 		// From MDN docs: every acts like the "for all" quantifier in mathematics.
 		// In particular, for an empty array, it returns true.
 		// So if the filter above returned an empty array, [].every(whatever) would return `true`
+		graphicEmbeds &&
 		graphicEmbeds.length > 0 &&
 		graphicEmbeds
 			.every((item) => item.canBeSyndicated === 'yes');


### PR DESCRIPTION
From MDN docs: 

> every acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns true. (It is vacuously true that all elements of the empty set satisfy any given condition.)

So instead `array && array.every` we need to have `array.length > 0 && array.every`