### PR TITLE
ACC-798 Update massive implementation by removing use of `db.reload()`

### DIFF
--- a/db/pg/index.js
+++ b/db/pg/index.js
@@ -41,11 +41,5 @@ module.exports = exports = async (options = DB) => {
 			db = await massive(conn);
 		}
 	}
-	else {
-		log.info(`${MODULE_ID} reloading DB instance => `, db.instance.$cn);
-
-		db = await db.reload();
-	}
-
 	return db;
 };


### PR DESCRIPTION
Ticket: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1108&projectKey=ACC&modal=detail&selectedIssue=ACC-798

Description:

Removes calls to `db.reload`, a function of [massive.js](https://massivejs.org/). 

We shouldn't be calling reload as it says in the documentation that [it is only necessary when changing the schema](https://massivejs.org/docs/connecting#reloading-the-api), which we do not do. Calling reload in the `else` block of `pg/index` meant that the database was being reloaded hundreds of times an hour, when changes aren't necessarily being made.  

A healthcare check on this package is constantly firing as a result of [a collision error that fires when a function has already been assigned](https://gitlab.com/dmfay/massive-js/-/blob/master/lib/database.js#L158), and this will hopefully go some way towards solving it. 