### PR TITLE
Upgrade n-es-client 1.8.0 -> 3.0.0; n-express 21.0.0 -> 21.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.35.1",
   "private": true,
   "dependencies": {
-    "@financial-times/n-es-client": "1.8.0",
-    "@financial-times/n-express": "21.0.0",
+    "@financial-times/n-es-client": "3.0.0",
+    "@financial-times/n-express": "21.0.9",
     "@financial-times/n-internal-tool": "7.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.2",


### PR DESCRIPTION
**This PR is dependent on https://github.com/Financial-Times/next-syndication-api/pull/292, which should be merged into the main branch first to implement the required changes for the `n-health` major upgrade, followed by a rebase of this branch onto the main branch (to pick up those changes).**

This PR upgrades the `n-es-client` dependency to v3.0.0 so that all of its Elasticsearch requests are directed to the new Elasticsearch v7 cluster.

It also upgrades the `n-express` version (which in turn upgrades the `next-metrics` version) so that metrics for requests to the Elasticsearch v7 cluster are captured correctly.

This app only uses `n-es-client` to make `get` and `mget` requests and the implementation applied here for those methods does not change between versions, meaning no further changes are required.