### PR TITLE
Upgrade n-internal-tool 7.0.0 -> 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",
     "@financial-times/n-express": "21.0.9",
-    "@financial-times/n-internal-tool": "7.0.0",
+    "@financial-times/n-internal-tool": "8.0.0",
     "@financial-times/n-mask-logger": "3.2.0",
     "@financial-times/session-decoder-js": "1.2.2",
     "ajv": "^6.0.0",


### PR DESCRIPTION
After the release of this PR https://github.com/Financial-Times/next-syndication-api/pull/293, the metrics captured for Elasticsearch requests were still called `aws-elastic-v3-mget`. The expectation was that the upgrade of `next-metrics` to the most version version (v5.0.16) would mean that such Elasticsearch requests would be named `aws-elastic-v7-mget`.

![Screenshot 2021-03-23 at 08 23 10](https://user-images.githubusercontent.com/10484515/112115989-b6f65000-8bb1-11eb-8302-42e182cc09a3.png)

This indicates that an older version of `next-metrics` is being used, and it seems the likely cause of this is via this app's dependency on `n-internal-tool`, which in turn has a dependency on an older version of `n-express`, which again in turn has a dependency on an older version of `next-metrics`.

This PR updates the `n-internal-tool` dependency to ensure that only the latest version of `next-metrics` is used by this app.

[`n-internal-tool` v8.0.0](https://github.com/Financial-Times/n-internal-tool/releases/tag/v8.0.0):
> this version drops support for versions of Node below 12, and includes n-health v5, which deprecates Pingdom checks. if upgrading to this version, follow the n-health v5 migration guide.

This app already uses Node v12, so that is fine, and this app has no Pingdom checks in its native heathchecks, so no migration required there either.