### PR TITLE
NOPS-602 Enabled debugging for mail-contributor

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -3,7 +3,7 @@
   CONTRIBUTOR_EMAIL:
     transport:
       debug: false
-      logger: false
+      logger: true
 
   CONVERT_FORMAT_COMMAND: "/app/pandoc-dpkg/usr/bin/pandoc"
 

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -27,7 +27,7 @@ const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolv
 const log = new Logger({ source: MODULE_ID });
 
 module.exports = exports = async (event) => {
-	log.info('contributor-check', { event.syndication_state, event.content_id, event.contract_id });
+	log.info('contributor-check', event);
 
 	if (event.syndication_state !== 'withContributorPayment' || event.state !== 'started') {
 		return;

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -24,9 +24,11 @@ const HTML = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/par
 const TXT = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/partial/email_contributor_body.txt.hbs'), 'utf8'), { noEscape: true });
 
 const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
-const log = new Logger({source: MODULE_ID});
+const log = new Logger({ source: MODULE_ID });
 
 module.exports = exports = async (event) => {
+	log.info('contributor-check', { event.syndication_state, event.content_id, event.contract_id });
+
 	if (event.syndication_state !== 'withContributorPayment' || event.state !== 'started') {
 		return;
 	}
@@ -40,11 +42,11 @@ module.exports = exports = async (event) => {
 	}
 
 	try {
-//		const verified = await transporter.verify();
-//
-//		if (!verified) {
-//			throw new Error(`${MODULE_ID} UnverifiedEmailTransportError =>`, verified);
-//		}
+		//		const verified = await transporter.verify();
+		//
+		//		if (!verified) {
+		//			throw new Error(`${MODULE_ID} UnverifiedEmailTransportError =>`, verified);
+		//		}
 
 		const [contract] = await db.syndication.get_contract_data([event.contract_id]);
 
@@ -67,8 +69,8 @@ module.exports = exports = async (event) => {
 		log.info(`${MODULE_ID} MAIL SENT =>`, res);
 
 		const data = contributor_payment && contributor_payment.contract_id !== null
-					? contributor_payment
-					: event;
+			? contributor_payment
+			: event;
 
 		data.email_sent = new Date();
 


### PR DESCRIPTION
[Ticket](https://financialtimes.atlassian.net/browse/NOPS-602)

**TL;DR of the issue:** When an article by a freelancer gets syndicated, and email gets sent out to notify Someone that they need to pay extra money to the freelancer. These emails have stopped some time ago and need to be reinstated. 

**What we've done:**
- We are unable to see any of the logs in the `mail-contributor` file. We suspect this may be because the `logs` have been disabled in the config file. This PR enables the logs to see if that helps. 
- We are unsure if the function as a whole is getting called at all, and if yes, does it `return` at a first possible step (ie - none of the articles syndicated are written by freelancers). This PR adds `log.info` immediately after initiation to allow us to see if this function is getting called, and with what `event`. 