### PR TITLE
Bump package.json version to 0.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",


### PR DESCRIPTION
I need to release a new version of this project in order to update the `n-es-client` version used in the deployment of the `next-syndication-dl` project. 

Bumping to `0.36.0` instead of `0.35.2` as the `n-es-client` version update is not backwards compatible and I am not sure about the versioning standard used for this project but this feels right.