### PR TITLE
NOPS-602 email client makeover for mail-contributor

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -19,6 +19,8 @@
     uri: "DATABASE_URL"
     user_name: "DATABASE_USER_NAME"
   DEFAULT_DB_ENDPOINT: "DEFAULT_DB_ENDPOINT"
+  EMAIL_PLATFORM_API_KEY: "EMAIL_PLATFORM_API_KEY"
+  EMAIL_PLATFORM_URL: "EMAIL_PLATFORM_URL"
   ES:
     access_key: "ES_AWS_ACCESS_KEY"
     secret_access_key: "ES_AWS_SECRET_ACCESS_KEY"
@@ -48,7 +50,7 @@
   apikey: "apikey"
 
   CONTRIBUTOR_EMAIL:
-    from: "GOOGLE_EMAIL_FROM_ADDRESS"
+    from: "EMAIL_PLATFORM_FROM_EMAIL"
     to: "GOOGLE_EMAIL_TO_ADDRESS"
     transport:
       auth:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "coveralls": "^2.13.1",
     "decompress": "^4.2.0",
     "eslint": "^3.19.0",
+    "fetch-mock": "^9.11.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.3.0",
     "nock": "^9.0.13",

--- a/test/worker/sync/db-persist/mail-contributor.spec.js
+++ b/test/worker/sync/db-persist/mail-contributor.spec.js
@@ -21,7 +21,7 @@ chai.use(sinonChai);
 
 const MODULE_ID = path.relative(`${process.cwd()}/test`, module.id) || require(path.resolve('./package.json')).name;
 
-describe.only(MODULE_ID, function () {
+describe(MODULE_ID, function () {
 	const contractResponse = require(path.resolve(`${FIXTURES_DIRECTORY}/contractResponse.json`));
 	let underTest;
 	let db;

--- a/test/worker/sync/db-persist/mail-contributor.spec.js
+++ b/test/worker/sync/db-persist/mail-contributor.spec.js
@@ -13,7 +13,6 @@ const NodeMailerJSONTransport = require('nodemailer/lib/json-transport');
 const MessageQueueEvent = require('../../../../queue/message-queue-event');
 
 const {
-	CONTRIBUTOR_EMAIL,
 	TEST: { FIXTURES_DIRECTORY }
 } = require('config');
 
@@ -92,10 +91,10 @@ describe.only(MODULE_ID, function () {
 
 		before(() => {
 			fetchMock.mock('https://ep.ft.com/send-api/send-by-address', {
-				"message": "OK",
-				"total_accepted_recipients": 1,
-				"total_rejected_recipients": 0,
-				"errors": []
+				'message': 'OK',
+				'total_accepted_recipients': 1,
+				'total_rejected_recipients': 0,
+				'errors': []
 			})
 		})
 

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -8,17 +8,18 @@ const { Logger } = require('../../../server/lib/logger');
 
 //const moment = require('moment');
 const moment = require('moment-timezone');
-const nodemailer = require('nodemailer');
+// const nodemailer = require('nodemailer');
 
 const {
 	CONTRIBUTOR_EMAIL
 } = require('config');
+const { EMAIL_PLATFORM_API_KEY, EMAIL_PLATFORM_URL, ACCOUNTS_EMAIL } = process.env
 
 const pg = require('../../../db/pg');
 
 const Handlebars = handlebars();
 
-const transporter = nodemailer.createTransport(JSON.parse(JSON.stringify(CONTRIBUTOR_EMAIL.transport)));
+// const transporter = nodemailer.createTransport(JSON.parse(JSON.stringify(CONTRIBUTOR_EMAIL.transport)));
 
 const HTML = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/partial/email_contributor_body.html.hbs'), 'utf8'), { noEscape: true });
 const TXT = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/partial/email_contributor_body.txt.hbs'), 'utf8'), { noEscape: true });
@@ -49,24 +50,47 @@ module.exports = exports = async (event) => {
 		//		}
 
 		const [contract] = await db.syndication.get_contract_data([event.contract_id]);
-
 		event.contract = contract;
 
 		log.debug('RECEIVED => ', event);
 
 		event.displayDate = moment.tz(event.time, CONTRIBUTOR_EMAIL.timezone).format(CONTRIBUTOR_EMAIL.date_display_format);
 
-		const transport = {
-			from: CONTRIBUTOR_EMAIL.from,
-			to: CONTRIBUTOR_EMAIL.to,
+		/// --- Email Platform Implementation --- 
+		const emailPlatformHeaders = {
+			'Content-Type': 'application/json',
+			'Authorization': EMAIL_PLATFORM_API_KEY
+		}
+
+		const emailPlatformBody = {
+			to: { address: [CONTRIBUTOR_EMAIL.to, ACCOUNTS_EMAIL] },
+			from: { address: CONTRIBUTOR_EMAIL.from, name: 'With Contributor Payment Syndication alert bot' },
 			subject: CONTRIBUTOR_EMAIL.subject,
-			html: HTML(event),
-			text: TXT(event)
-		};
+			htmlContent: HTML(event),
+			plainTextContent: TXT(event)
+		}
 
-		const res = await transporter.sendMail(transport);
+		const res = await fetch(EMAIL_PLATFORM_URL, {
+			method: 'POST',
+			headers: emailPlatformHeaders,
+			body: JSON.stringify(emailPlatformBody)
+		})
 
-		log.info(`${MODULE_ID} MAIL SENT =>`, res);
+		if (res.total_rejected_recipients !== 0) {
+			log.info('Some emails were not delivered. Not delivered count', res.total_rejected_recipients)
+		}
+
+		// const transport = {
+		// from: CONTRIBUTOR_EMAIL.from,
+		// to: CONTRIBUTOR_EMAIL.to,
+		// subject: CONTRIBUTOR_EMAIL.subject,
+		// html: HTML(event),
+		// text: TXT(event)
+		// };
+
+		// const res = await transporter.sendMail(transport);
+
+		log.info(`${MODULE_ID} MAIL SENT =>`, res.json());
 
 		const data = contributor_payment && contributor_payment.contract_id !== null
 			? contributor_payment

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -7,20 +7,18 @@ const fetch = require('node-fetch');
 const handlebars = require('../../../server/lib/handlebars');
 const { Logger } = require('../../../server/lib/logger');
 
-//const moment = require('moment');
 const moment = require('moment-timezone');
-// const nodemailer = require('nodemailer');
 
 const {
-	CONTRIBUTOR_EMAIL
+	CONTRIBUTOR_EMAIL,
+	EMAIL_PLATFORM_API_KEY,
+	EMAIL_PLATFORM_URL,
+	ACCOUNTS_EMAIL
 } = require('config');
-const { EMAIL_PLATFORM_API_KEY, EMAIL_PLATFORM_URL, ACCOUNTS_EMAIL } = process.env
 
 const pg = require('../../../db/pg');
 
 const Handlebars = handlebars();
-
-// const transporter = nodemailer.createTransport(JSON.parse(JSON.stringify(CONTRIBUTOR_EMAIL.transport)));
 
 const HTML = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/partial/email_contributor_body.html.hbs'), 'utf8'), { noEscape: true });
 const TXT = Handlebars.compile(fs.readFileSync(path.resolve('./server/views/partial/email_contributor_body.txt.hbs'), 'utf8'), { noEscape: true });
@@ -44,12 +42,6 @@ module.exports = exports = async (event) => {
 	}
 
 	try {
-		//		const verified = await transporter.verify();
-		//
-		//		if (!verified) {
-		//			throw new Error(`${MODULE_ID} UnverifiedEmailTransportError =>`, verified);
-		//		}
-
 		const [contract] = await db.syndication.get_contract_data([event.contract_id]);
 		event.contract = contract;
 
@@ -57,7 +49,6 @@ module.exports = exports = async (event) => {
 
 		event.displayDate = moment.tz(event.time, CONTRIBUTOR_EMAIL.timezone).format(CONTRIBUTOR_EMAIL.date_display_format);
 
-		/// --- Email Platform Implementation --- 
 		const emailPlatformHeaders = {
 			'Content-Type': 'application/json',
 			'Authorization': EMAIL_PLATFORM_API_KEY
@@ -80,16 +71,6 @@ module.exports = exports = async (event) => {
 		if (res.total_rejected_recipients !== 0) {
 			log.info('Some emails were not delivered. Not delivered count', res.total_rejected_recipients)
 		}
-
-		// const transport = {
-		// from: CONTRIBUTOR_EMAIL.from,
-		// to: CONTRIBUTOR_EMAIL.to,
-		// subject: CONTRIBUTOR_EMAIL.subject,
-		// html: HTML(event),
-		// text: TXT(event)
-		// };
-
-		// const res = await transporter.sendMail(transport);
 
 		log.info(`${MODULE_ID} MAIL SENT =>`, res.json());
 

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const fetch = require('node-fetch');
 
 const handlebars = require('../../../server/lib/handlebars');
 const { Logger } = require('../../../server/lib/logger');


### PR DESCRIPTION
[Ticket](https://financialtimes.atlassian.net/browse/NOPS-602)

Issue: Due to gmail security updates, gmail blocked `nodemailer` attempts to log in to sock-puppet send an email. As such, relevant alerts to pay the freelancers didn't get sent. 

This PR: 
- removes `nodemailer` functionality from `mail-contributor.js` and replaces it with [e-mail platform's POST send by address](https://ep.ft.com/docs/email-send-api/#api-Send-Post_send-by-address)
- you'll notice there's the ACCOUNTS_EMAIL as one of the recipients. I set that to my email address so that I get to see a copy of the email. Once I'm happy it looks good, I'll remove it. 

This PR does NOT:
- remove modules and google environment variables. My linter does not work for this repo and I am not confident to do this without a machine shouting at me if I do something wrong.  
- check if nodemailer is used elsewhere / replace that. Ticket is only to deal with withContributor emails getting missed, so anything else should be a separate ticket.