### PR TITLE
ACC-1005 Added a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Description
+<!--- Describe your changes in detail -->
+
+### Ticket
+<!-- Add link to the corresponding ticket -->
+
+### What is the new version number in package.js?
+<!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->
+
+### Link to the next-syndication-dl PR which bumps the next-syndication-api version
+<!-- Add link to the PR -->


### PR DESCRIPTION
Following https://github.com/Financial-Times/incident-reports/issues/441 it became obvious that the special release / deploy procedure isn't documented visibly enough. To try to prevent similar issues in the future, this PR introduces a template that anyone raising the PR should follow - this should highlight the special procedure. 