### PR TITLE
NOPS-602 race condition fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.39.0",
+  "version": "0.38.1",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -74,7 +74,7 @@ module.exports = exports = async (event) => {
 			log.info('Some emails were not delivered. Not delivered count', res.total_rejected_recipients)
 		}
 
-		let responseData = await res.json();
+		const responseData = await res.json();
 
 		log.info(`${MODULE_ID} MAIL SENT =>`, responseData);
 

--- a/worker/sync/db-persist/mail-contributor.js
+++ b/worker/sync/db-persist/mail-contributor.js
@@ -74,8 +74,7 @@ module.exports = exports = async (event) => {
 			log.info('Some emails were not delivered. Not delivered count', res.total_rejected_recipients)
 		}
 
-		let responseData;
-		res.json().then(data => responseData = data)
+		let responseData = await res.json();
 
 		log.info(`${MODULE_ID} MAIL SENT =>`, responseData);
 


### PR DESCRIPTION
### Description
Follow up to #305 

I merged before Tolu had a chance to comment and he pointed out that my `res.json()` fix will hit a race condition and suggested simplifying to `await res.json()`

This PR fixed the dodgy fix to `res.json()`.

### Ticket
https://financialtimes.atlassian.net/browse/NOPS-602

### What is the new version number in package.js?
0.39.0 (because I already released the 0.38.0

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
I'm going to change this one to 0.39.0
https://github.com/Financial-Times/next-syndication-dl/pull/57