### PR TITLE
Revert "ACC-1106 SSL fine tune for DB connection"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 2018,
+		'ecmaVersion': 2017,
 		'sourceType': 'module'
 	},
 	'rules': {

--- a/db/pg/index.js
+++ b/db/pg/index.js
@@ -12,15 +12,6 @@ const { DB } = require('config');
 const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
 const log = new Logger({source: MODULE_ID});
 
-const sslSetUp = {
-	ssl: true,
-	extra: {
-		ssl: {
-			rejectUnauthorized: false,
-		},
-	}
-}
-
 let db;
 
 module.exports = exports = async (options = DB) => {
@@ -28,7 +19,8 @@ module.exports = exports = async (options = DB) => {
 		log.info(`${MODULE_ID} creating new DB instance with options => `, options);
 
 		if (options.uri) {
-			const conn = Object.assign({ ...sslSetUp}, pgConn.parse(options.uri));
+			const conn = Object.assign({ ssl: { rejectUnauthorized : false } }, pgConn.parse(options.uri));
+
 			log.info(`${MODULE_ID} creating new DB instance with URI String => `, conn);
 
 			db = await massive(conn);
@@ -39,9 +31,12 @@ module.exports = exports = async (options = DB) => {
 				host: options.host,
 				password: options.password,
 				port: options.port,
-				user: options.user_name,
-				...sslSetUp,
+				user: options.user_name
 			};
+
+			if (options.ssl === true) {
+				conn.ssl = { rejectUnauthorized : false };
+			}
 
 			db = await massive(conn);
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.2",
+  "version": "0.38.1",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",
@@ -107,7 +107,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel && make verify -j3",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
       "pre-push": "make verify -j3"
     }
   }

--- a/test/db/pg/index.spec.js
+++ b/test/db/pg/index.spec.js
@@ -57,42 +57,9 @@ describe(MODULE_ID, function () {
 			port: 'DB_PORT',
 			database: 'DB_NAME',
 			user: 'DB_USER',
-			password: 'DB_PASSWORD',
-			ssl: true,
-			extra: {
-				ssl: {
-					rejectUnauthorized: false,
-				},
-			}
+			password: 'DB_PASSWORD'
 		});
 
 		expect(DB).to.equal(db);
 	});
-
-	it('creates a new database instance if options do not match', async function() {
-		beforeEach(() => {
-			db = null;
-		})
-
-		const DB = await underTest({
-			uri: 'DATABASE_URL'
-		});
-
-		expect(massiveStub).to.have.been.calledWith({
-			database: 'DATABASE_URL',
-			user: '',
-			password: '',
-			port: null,
-			host: null,
-			ssl: true,
-			extra: {
-				ssl: {
-					rejectUnauthorized: false,
-				},
-			}
-		});
-
-		expect(DB).to.equal(db);
-	})
-
 });


### PR DESCRIPTION
Reverts Financial-Times/next-syndication-api#309

The release has taken Syndication down with a massive spike of `error_message: self signed certificate`. Generally the recommended solution is to use `ssl = {rejectUnauthorised: false}` which is what we had to start with. 

I guess I don't need to worry about making a new release because `next-syndication-dl` `main` still looks for 0.38.1 and this PR reverts to that version?