### PR TITLE
Make verify now runs on pre-commit as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-commit": "node_modules/.bin/secret-squirrel && make verify -j3",
       "pre-push": "make verify -j3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.1",
+  "version": "0.38.3",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",


### PR DESCRIPTION
### Description
This has been annoying me for yonks. You make a commit, try to push, and then linter pipes up. So you either need to play the uncommit game or make a "fix typos" commit. I'm fed up of this.

It also bumps up the version do that DL can consume something that isn't buggy. 

### Ticket
no ticket. 

### What is the new version number in package.js?
0.38.3

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/59