### PR TITLE
ACC-1106 SSL fix, take two

### DIFF
--- a/db/pg/index.js
+++ b/db/pg/index.js
@@ -19,7 +19,7 @@ module.exports = exports = async (options = DB) => {
 		log.info(`${MODULE_ID} creating new DB instance with options => `, options);
 
 		if (options.uri) {
-			const conn = Object.assign({ ssl: { rejectUnauthorized : false } }, pgConn.parse(options.uri));
+			const conn = Object.assign({ ssl: { rejectUnauthorized : false, sslmode: require } }, pgConn.parse(options.uri));
 
 			log.info(`${MODULE_ID} creating new DB instance with URI String => `, conn);
 
@@ -35,7 +35,7 @@ module.exports = exports = async (options = DB) => {
 			};
 
 			if (options.ssl === true) {
-				conn.ssl = { rejectUnauthorized : false };
+				conn.ssl = { rejectUnauthorized : false, sslmode: require };
 			}
 
 			db = await massive(conn);

--- a/db/pg/index.js
+++ b/db/pg/index.js
@@ -19,7 +19,7 @@ module.exports = exports = async (options = DB) => {
 		log.info(`${MODULE_ID} creating new DB instance with options => `, options);
 
 		if (options.uri) {
-			const conn = Object.assign({ ssl: { rejectUnauthorized : false, sslmode: require } }, pgConn.parse(options.uri));
+			const conn = Object.assign({ ssl: { rejectUnauthorized : false, sslmode: 'require' } }, pgConn.parse(options.uri));
 
 			log.info(`${MODULE_ID} creating new DB instance with URI String => `, conn);
 
@@ -35,7 +35,7 @@ module.exports = exports = async (options = DB) => {
 			};
 
 			if (options.ssl === true) {
-				conn.ssl = { rejectUnauthorized : false, sslmode: require };
+				conn.ssl = { rejectUnauthorized : false, sslmode: 'require' };
 			}
 
 			db = await massive(conn);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",


### PR DESCRIPTION
### Description
#309 took Syndication down, so it's probably not the way to go. See that PR for the background for this ticket. 

This PR takes a wild guess that `massive.js` dependency will pick out `sslmode` from the `ssl` object based on this piece of code https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/connection-parameters.js#L137

This PR add `sslmode: require` to `ssl` object. Heroku [docs](https://devcenter.heroku.com/articles/heroku-postgresql#remote-connections) state `sslmode: require` is needed for remote connections. 

### Ticket
https://financialtimes.atlassian.net/browse/ACC-1106

### What is the new version number in package.js?
0.38.4

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
Will wait to make sure this PR doesn't break Syndication before making a PR in DL. 
