### PR TITLE
NOPS-920. Changed default severity for error rate healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",

--- a/server/app.js
+++ b/server/app.js
@@ -32,7 +32,10 @@ const app = module.exports = express({
 		require('../health/db-sync-state'),
 		require('../health/sqs'),
 		require('../health/error-spikes'),
-	]
+	],
+	errorRateHealthcheck: {
+		severity: 2
+	}
 });
 
 const middleware = [


### PR DESCRIPTION
### Description

Changed the severity of error rate health check from 3 to 2
### Ticket
https://financialtimes.atlassian.net/browse/NOPS-920

### What is the new version number in package.js?
0.38.4

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->
https://github.com/Financial-Times/next-syndication-dl/pull/60