### PR TITLE
Housekeeping on logs and healthchecks

### DIFF
--- a/db/pg/index.js
+++ b/db/pg/index.js
@@ -7,7 +7,7 @@ const { Logger } = require('../../server/lib/logger');
 const massive = require('massive');
 const pgConn = require('pg-connection-string');
 
-const { DB } = require('config');
+const { DB, NODE_ENV } = require('config');
 
 const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
 const log = new Logger({source: MODULE_ID});
@@ -16,7 +16,7 @@ let db;
 
 module.exports = exports = async (options = DB) => {
 	if (!db || options !== DB) {
-		log.info(`${MODULE_ID} creating new DB instance with options => `, options);
+		log.info(`${MODULE_ID} (node_env: ${NODE_ENV}) creating new DB instance with options => `, options);
 
 		if (options.uri) {
 			const conn = Object.assign({ ssl: { rejectUnauthorized : false } }, pgConn.parse(options.uri));

--- a/health/db-sync-state.js
+++ b/health/db-sync-state.js
@@ -41,6 +41,7 @@ module.exports = exports = new (class DBSyncStateCheck extends nHealthCheck {
 })({
 	businessImpact: 'The Syndication database\'s computed tables are not in-sync with the base table data and, as such, may be showing incorrect data to users.',
 	name: 'Syndication database data integrity',
+	id: 'next-syndication-api-db-data-integrity',
 /*eslint-disable*/
 	panicGuide: `To force a reload of all the computed tables, run:
 

--- a/health/error-spikes.js
+++ b/health/error-spikes.js
@@ -9,6 +9,7 @@ module.exports = nHealth.runCheck({
 	threshold,
 	samplePeriod: `${samplePeriod}min`,
 	name: `${statusCode} rate for articles is acceptable`,
+	id: 'next-syndication-api-error-spikes',
 	severity: 1,
 	businessImpact: `Error rate for the syndication-api has exceeded a threshold of ${threshold * 100}% over the last ${samplePeriod} minutes.`,
 	technicalSummary: `The proportion of ${statusCode} (Unauthorized) responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of ${threshold} over the last ${samplePeriod} minutes`,

--- a/health/sqs.js
+++ b/health/sqs.js
@@ -129,6 +129,7 @@ module.exports = exports = new (class SQSCheck extends nHealthCheck {
 })({
 	businessImpact: 'Saved and downloaded items are not currently being processed by the Syndication API and, as such, are backing up in the Syndication SQS Queue.',
 	name: 'Syndication SQS Queue message processing',
+	id: 'next-syndication-api-sqs',
 /*eslint-disable*/
 	panicGuide: `1. check SQS Queue (next-syndication-downloads-prod) on Infra Prod to see if there are messages outstanding on the queue (Monitoring --> Approximate Number Of Messages Visible chart, or, Send and Recieve Messages --> Poll for Messages --> inspect the message id for message details).
 2. If there is a message in the queue, check/tail the server/worker logs on Heroku:


### PR DESCRIPTION
### Description
This PR
- adds a NODE_ENV info to our logs to help with [ACC-1106](https://financialtimes.atlassian.net/browse/ACC-1106). Dawn spotted that the bucket names are different between the calls that are failing vs those that are successful which imply that maybe the way our secrets are loaded may be related? 
- adds IDs to health checks because Dawn asked why things are green, and well, without the ID the connection to the data source is questionable (the graph doesn't work, so I'm guessing the values may not be correct either) and the checks aren't complaint anyway. See [FT Health Check standard document](https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit) for more info on health checks. 

![Screenshot 2021-07-20 at 11 31 03](https://user-images.githubusercontent.com/31079643/126310180-fc2d6702-717b-4396-923b-d4dd56e2c50d.png)

### Ticket
n/a

### What is the new version number in package.js?
This is logs and housekeeping, release isn't really needed. 
