### PR TITLE
ACC-1169 main branch name change chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -149,7 +149,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_master
+            <<: *filters_ignore_main
       - test:
           requires:
             - build
@@ -161,7 +161,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
       - test:
           requires:
             - build
@@ -174,7 +174,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xmldom": "^0.3.0"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^6.0.0",
+    "@financial-times/n-gage": "^8.2.0",
     "@financial-times/n-heroku-tools": "^10.0.0",
     "@financial-times/n-test": "^1.13.2",
     "chai": "^4.0.2",


### PR DESCRIPTION
### Description
Following the branch name change, this PR handles associated chores as per https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master)

- upgrades n-gage
- updates CI yaml to use the new name

### Ticket
https://financialtimes.atlassian.net/browse/ACC-1169

