### PR TITLE
Add a stop-local command to stop all clusters when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ run-local:
 	./node_modules/.bin/pm2 start procfile.json
 	./node_modules/.bin/pm2 logs
 
+stop-local:
+	./node_modules/.bin/pm2 stop procfile.json
+
 run-monit:
 	./node_modules/.bin/pm2 monit
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ This will start the `next-syndication-api` the associated worker processes and t
 
 You can also run `make run-monit` to bring up the [PM2 process monitor](https://www.npmjs.com/package/pm2#cpu--memory-monitoring).
 
+Once you have stopped the app running, you will need to run `make stop-local` to stop all the clusters running too.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
### Description
We had a command to run locally which set up a bunch of clusters, but no corresponding stop command to shut down the clusters. This meant that even when you exited the app with `Ctrl-C`, there would still be clusters running the app. This made a clean restart difficult. 

### Ticket
None, minor fix

### What is the new version number in package.js?
This is not something to be used in production, its a command for operating the app locally

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
N/A
