### PR TITLE
Db persist worker triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
       "server/app-dl.js",
       "server/env.js",
       "server/init.js",
+      "server/controllers/nonproduction/db-persist.js",
       "worker/index.js",
       "worker/crons/index.js",
       "worker/crons/backup/callback.js",

--- a/server/app.js
+++ b/server/app.js
@@ -99,8 +99,12 @@ app.post('/syndication/download-format', middleware, require('./controllers/upda
 app.get('/syndication/reload', middleware, require('./controllers/reload'));
 
 if (process.env.NODE_ENV !== 'production') {
+	// trigger the cron worker code
 	app.get('/syndication/backup', middleware, require('./controllers/backup'));
 	app.get('/syndication/redshift', middleware, require('./controllers/redshift'));
+	// trigger the db-persist code
+	// note that this will add data to the connected database, so use only on test databases
+	app.post('/syndication/db-persist', middleware, require('./controllers/nonproduction/db-persist'));
 }
 
 const contractsMiddleware = [

--- a/server/controllers/nonproduction/db-persist.js
+++ b/server/controllers/nonproduction/db-persist.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { Logger } = require('../../lib/logger');
+
+const ACL = {
+	user: false,
+	superuser: false,
+	superdooperuser: true
+};
+
+/* values for the post request
+* saved and deleted run in upsert history, started runs in mail contributor
+* you can also override any of the base dummy event items
+* expected body:
+{
+	"state": "[saved|deleted|started]",
+	"user": {
+		"first_name": stringValue,
+		"surname": stringValue,
+		"email": stringValue,
+		"id": valid User ID that is already in the syndication database (e.g. any dev with S1 product)
+	},
+	"_id": random ID string,
+	"content_id": content ID for an article,
+	"content_url": content url matching that article,
+	"user_id": same user ID as above
+}
+*/
+module.exports = exports = async (req, res) => {
+	const log = new Logger({req, res, source: 'controllers/nonproduction/db-persist'});
+	try {
+		const { locals: { user } } = res;
+
+		if (!user || ACL[user.role] !== true) {
+			res.sendStatus(401);
+
+			return;
+		}
+
+		const eventSettings = req.body;
+		const baseDummyEvent = {
+			syndication_state: 'withContributorPayment',
+			contract_id: process.env.FT_STAFF_CONTRACT_ID,
+			title: 'test that db persist works',
+			has_graphics: false,
+			content_type: 'article',
+			asset_type:'FT Article',
+			contributor_content: true,
+			iso_lang_code: 'en',
+			licence_id: process.env.FT_STAFF_LICENCE_ID,
+			time: '2021-09-23'
+		};
+		const dummyEvent = Object.assign(baseDummyEvent, eventSettings);
+
+		const mailContrib = require('../../../worker/sync/db-persist/mail-contributor');
+		const upsertHistory = require('../../../worker/sync/db-persist/upsert-history');
+
+		if (dummyEvent.state === 'started') {
+			await mailContrib(dummyEvent);
+		} else if (dummyEvent.state === 'saved' || dummyEvent.state === 'deleted') {
+			await upsertHistory(dummyEvent);
+		} else {
+			log.error('Please check that you passed in a valid request body');
+			res.sendStatus(400);
+		}
+		res.status(200).end();
+	}
+	catch(error) {
+		log.error(error);
+		res.sendStatus(500);
+	}
+};

--- a/server/middleware/decode-session.js
+++ b/server/middleware/decode-session.js
@@ -10,7 +10,6 @@ module.exports = exports = (req, res, next) => {
 	const log = new Logger({req, res, source: 'middleware/decode-session'});
 	const sessionToken = req.cookies.FTSession;
 	const sessionSecureToken = req.cookies.FTSession_s;
-
 	if (!sessionToken || !sessionSecureToken) {
 		res.redirect(`https://accounts.ft.com/login?location=${req.originalUrl}`);
 		return;


### PR DESCRIPTION
### Description
Add an endpoint where we can trigger the db-persist workers so we can test they write to the database for upgrade work

### Ticket
n/a, part of syndication database upgrade work

### What is the new version number in package.js?
n/a this is for testing code, won't run in production

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
n/a this is for testing code, won't run in production
