### PR TITLE
Set item content to empty string if it is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.38.5",
+  "version": "0.38.6",
   "private": true,
   "dependencies": {
     "@financial-times/n-es-client": "3.0.0",

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -51,9 +51,7 @@ function decorateContract(contract, hasGraphics = false) {
 		acc[asset.content_type] = asset;
 
 		asset.assets.forEach(item => {
-			if (Array.isArray(item.content_set)) {
-				item.content = item.content_set.join('; ');
-			}
+			item.content = (Array.isArray(item.content_set)) ? item.content_set.join('; ') : '';
 
 			if (Array.isArray(item.addendums) && item.addendums.length) {
 				asset.hasAddendums = true;


### PR DESCRIPTION
### Description
Ensure that item.content is set to empty string if content-areas are null

### Ticket
na

### What is the new version number in package.js?
0.38.6

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/64
