### PR TITLE
Add __syndication download path to skip preflight

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -60,7 +60,7 @@ const middleware = [
 ];
 
 app.get('/__gtg', (req, res) => res.sendStatus(200));
-
+app.get('/__syndication/', (req, res) => res.sendStatus(200));
 // this is here to stop weird error logs, we can't find what exactly is pinging this endpoint
 // so this keeps everyone happy... :P
 app.get('/syndication/admin/save', (req, res) => res.sendStatus(204));
@@ -81,6 +81,10 @@ app.get('/syndication/content/:content_id', middleware, require('./controllers/g
 // download a content item for a contract
 // IMPORTANT: THIS IS ONLY USED IN DEVELOPMENT. IN PRODUCTION THIS ENDPOINT IS RUN FROM ./app-dl.js
 app.get('/syndication/download/:content_id', middleware, require('./controllers/download-by-content-id'));
+
+// test to see if skipping preflight fixes the downloading videos timeout problem
+// https://github.com/Financial-Times/next-service-registry/pull/1075
+app.get('/__syndication/download/:content_id', middleware, require('./controllers/download-by-content-id'));
 
 // un/save a content item to a contract
 app.get('/syndication/save/:content_id', middleware, require('./controllers/save-by-content-id'));


### PR DESCRIPTION
### Description
While working on the documentation, I came across a comment about why the next-syndication-dl app exists that made me suspect skipping preflight might get the downloads working without needing a separate app. I can't test that locally though.

More details in description for https://github.com/Financial-Times/next-service-registry/pull/1075

### Ticket
na, testing if a path works

### What is the new version number in package.js?
na not for the download app

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
na not for the download app
