### PR TITLE
ACC-698 Add API healthchecks for 5xx error responses

### DIFF
--- a/health/server-error-spikes.js
+++ b/health/server-error-spikes.js
@@ -1,0 +1,16 @@
+const nHealth = require('n-health');
+const threshold =5;
+const samplePeriod = 60; // minutes
+
+module.exports = nHealth.runCheck({
+	type: 'graphiteThreshold',
+	metric: `asPercent(summarize(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.5*.count), "${samplePeriod}min", "sum", true), summarize(sumSeries(next.heroku.syndication-api.web_*.express.default_route_GET.res.status.*.count), "${samplePeriod}min", "sum", true))`,
+	threshold,
+	samplePeriod: `${samplePeriod}min`,
+	name: '5xx rate for next-syndication-api is acceptable',
+	id: 'next-syndication-api-5xx-error-spikes',
+	severity: 1,
+	businessImpact: `Server error rate for the syndication-api has exceeded a threshold of ${threshold * 100}% over the last ${samplePeriod} minutes.`,
+	technicalSummary: `The proportion of 5xx responses for syndication API requests across all heroku dynos vs all responses is higher than a threshold of ${threshold} over the last ${samplePeriod} minutes`,
+	panicGuide: 'Check the heroku logs for the app for any error messages.'
+})

--- a/server/app-dl.js
+++ b/server/app-dl.js
@@ -30,7 +30,7 @@ const app = module.exports = express({
 	withFlags: true,
 	healthchecks: [
 		require('../health/dl-error-spikes'),
-	]
+	] //this healthcheck probably needs to be removed
 });
 
 const middleware = [

--- a/server/app.js
+++ b/server/app.js
@@ -32,7 +32,8 @@ const app = module.exports = express({
 		require('../health/db-sync-state'),
 		require('../health/sqs'),
 		require('../health/error-spikes'),
-		require('../health/dl-error-spikes')
+		require('../health/dl-error-spikes'),
+		require('../health/server-error-spikes')
 	],
 	errorRateHealthcheck: {
 		severity: 2

--- a/server/app.js
+++ b/server/app.js
@@ -32,6 +32,7 @@ const app = module.exports = express({
 		require('../health/db-sync-state'),
 		require('../health/sqs'),
 		require('../health/error-spikes'),
+		require('../health/dl-error-spikes')
 	],
 	errorRateHealthcheck: {
 		severity: 2


### PR DESCRIPTION
### Description
Add API healthchecks for 5xx error responses.
Aiming to trigger when the 5xx/total response ratio is over 5%.
Will need to deploy in order to test.

This is the panel that contains the path that looks for 5xx error responses: https://grafana.ft.com/d/Px4RNC0nk/asier-playground?orgId=1&from=now-7d&to=now

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1108?modal=detail&selectedIssue=ACC-698)

### What is the new version number in package.js?
<!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->
