### PR TITLE
Prevent app crashes caused by unhandled rejections

### DIFF
--- a/server/middleware/get-licence-access-auth-token.js
+++ b/server/middleware/get-licence-access-auth-token.js
@@ -41,6 +41,6 @@ module.exports = exports = async (req, res, next) => {
 
 		res.sendStatus(401);
 
-		throw error;
+		next(error);
 	}
 };

--- a/server/middleware/get-syndication-licence-for-user.js
+++ b/server/middleware/get-syndication-licence-for-user.js
@@ -78,6 +78,6 @@ module.exports = exports = async (req, res, next) => {
 
 		res.sendStatus(401);
 
-		throw error;
+		next(error);
 	}
 };

--- a/server/middleware/get-user-access-auth-token.js
+++ b/server/middleware/get-user-access-auth-token.js
@@ -51,6 +51,6 @@ module.exports = exports = async (req, res, next) => {
 
 		res.sendStatus(401);
 
-		throw error;
+		next(error);
 	}
 };

--- a/server/middleware/get-user-profile.js
+++ b/server/middleware/get-user-profile.js
@@ -83,6 +83,6 @@ module.exports = exports = async (req, res, next) => {
 
 		res.sendStatus(401);
 
-		throw error;
+		next(error);
 	}
 };

--- a/server/middleware/is-syndication-user.js
+++ b/server/middleware/is-syndication-user.js
@@ -92,6 +92,6 @@ module.exports = exports = async (req, res, next) => {
 
 		res.sendStatus(503);
 
-		throw error;
+		next(error);
 	}
 };


### PR DESCRIPTION
### Description

These middlewares have always resulted in unhandled promise rejections.
Express (v4) can't handle thrown errors in asynchronous routes and so
these errors weren't handled correctly.

The behaviour for unhandled rejections changed in Node.js 16, they used
to just log a warning but now they result in app crashes. This is why we
haven't had lots of app crashes until recently. See the [migration
notes](https://github.com/Financial-Times/next/wiki/Node-14-%26-16-Migration-Guide#breaking-changes-to-look-out-for)

I'm now handling all the promise rejections properly by passing the
error onto the next route rather than rethrowing it. This should protect
the app from going down if there's an error in the routes.

### Ticket
No ticket but it relates to [incident 1554](https://financialtimes.slack.com/archives/C03HF9PG7A9).
