### PR TITLE
Prevent app crashes caused by unhandled rejections 2

### DIFF
--- a/server/middleware/get-syndication-licence-for-user.js
+++ b/server/middleware/get-syndication-licence-for-user.js
@@ -33,7 +33,18 @@ module.exports = exports = async (req, res, next) => {
 		if (!syndicationLicences.length) {
 			const isProduction = process.env.NODE_ENV === 'production';
 			if (isProduction) {
-				throw new ReferenceError(`No Syndication Licence found for user#${res.locals.userUuid} using ${URI}`);
+				const error = new ReferenceError(
+					`No Syndication Licence found for user#${res.locals.userUuid} using ${URI}`
+				);
+				log.error('LICENCE_FOUND_ERROR', {
+					event: 'LICENCE_FOUND_ERROR',
+					error,
+					URI,
+					headers,
+					user: res.locals.userUuid
+				});
+				res.sendStatus(404);
+				next(error);
 			}
 
 			syndicationLicences.push({
@@ -52,7 +63,18 @@ module.exports = exports = async (req, res, next) => {
 								|| syndicationLicences[0];
 
 		if (!syndicationLicence) {
-			throw new ReferenceError(`No Syndication Licence found for user#${res.locals.userUuid} using ${URI}`);
+			const error = new ReferenceError(
+				`No Syndication Licence found for user#${res.locals.userUuid} using ${URI}`
+			);
+			log.error('LICENCE_FOUND_ERROR', {
+				event: 'LICENCE_FOUND_ERROR',
+				error,
+				URI,
+				headers,
+				user: res.locals.userUuid
+			});
+			res.sendStatus(404);
+			next(error);
 		}
 
 		res.locals.licence = syndicationLicence;


### PR DESCRIPTION
Description
These middlewares have always resulted in unhandled promise rejections.
Express (v4) can't handle thrown errors in asynchronous routes and so
these errors weren't handled correctly.

The behaviour for unhandled rejections changed in Node.js 16, they used
to just log a warning but now they result in app crashes. This is why we
haven't had lots of app crashes until recently. See the migration
notes

I'm now handling all the promise rejections properly by passing the
error onto the next route rather than rethrowing it. This should protect
the app from going down if there's an error in the routes.

Ticket
No ticket but it relates to [incident 1554](https://financialtimes.slack.com/archives/C03HF9PG7A9).
