### PR TITLE
ACC-1833-Update logger to mask db uri and user_name

### DIFF
--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -8,6 +8,8 @@ const _logger = new MaskLogger([
 	'contract_id',
 	'first_name',
 	'surname',
+	'uri',
+	'user_name',
 	'x-api-key'
 ]);
 


### PR DESCRIPTION
### Description
[This splunk query](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22%2Fvar%2Flog%2Fapps%2Fheroku%2Fft-next-syndication-api.log%22%20%7C%20spath%20message%20%7C%20regex%20message%3D%22creating%20new%20DB%20instance%20with%20options%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1w&latest=now&sid=1659948508.2839421) shows that we are loggin db data(username and connection uri which includes the password).

This PR will tend to mask user_name and uri  data that is logged in next-syndication-api logger.

[Jira-ticket](https://financialtimes.atlassian.net/browse/ACC-1833)

