### PR TITLE
ACC-2020- Fix: Bumping up package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
@@ -20,10 +20,10 @@
     "jsonpath": "^1.0.0",
     "massive": "^6.1.1",
     "mime-types": "^2.1.5",
+    "moment": "^2.29.4",
     "moment-timezone": "^0.5.35",
     "n-eager-fetch": "6.0.0",
     "n-health": "7.0.2",
-    "moment": "^2.29.4",
     "nforce": "^1.7.0",
     "node-schedule": "^1.2.5",
     "node-slack": "^0.0.7",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR is bumping the `package.json` version to trigger a new release as part of [this PR](https://github.com/Financial-Times/next-syndication-api/pull/403)

### Ticket
<!-- Add link to the corresponding ticket -->
[Ticket](https://financialtimes.atlassian.net/browse/ACC-2020)

