### PR TITLE
Increment package.json version 0.41.4 -> 0.41.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.4",
+  "version": "0.41.6",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",


### PR DESCRIPTION
### Description
This PR applies the release changes I forgot to include as part of https://github.com/Financial-Times/next-syndication-api/pull/411. It looks like the release will also include some preceding commits but that seems okay.

The reason this PR skips from 0.41.4 to 0.41.6 (and misses 0.41.5) is because that version was released [here](https://github.com/Financial-Times/next-syndication-api/releases/tag/v0.41.5), although without the corresponding change to the `package.json`.

### Ticket
N/A

### What is the new version number in package.js?
0.41.6

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/120