### PR TITLE
Correct reference to package.json in .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 ### Ticket
 <!-- Add link to the corresponding ticket -->
 
-### What is the new version number in package.js?
+### What is the new version number in package.json?
 <!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->
 
 ### Link to the next-syndication-dl PR which bumps the next-syndication-api version


### PR DESCRIPTION
### Description
This PR corrects a reference to the `package.json` file in the `.github/PULL_REQUEST_TEMPLATE.md` to make clearer where the new version number should live.

### Ticket
N/A

### What is the new version number in package.js?
N/A

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
N/A