### PR TITLE
ACC-2118 Capitalize first letter of time period before save to DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.6",
+  "version": "0.41.7",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/server/lib/reformat-salesforce-contract.js
+++ b/server/lib/reformat-salesforce-contract.js
@@ -55,15 +55,25 @@ module.exports = exports = SFContract => {
 
 
 function formatAsset(item) {
+	//if the contract data is coming all lowercase from salesforce, capitalize the first letter before saving to the DB. This is because of the enum_time_period in next-syndication-db-schema, which only accepts uppercase.
+	const lowerCaseEnumTimePeriods = ['day', 'week', 'month', 'year'];
+
+	let maxPermittedPrintUsagePeriod = item.maxPermittedPrintUsagePeriod || 'Year';
+
+	let maxPermittedOnlineUsagePeriod = item.maxPermittedOnlineUsagePeriod || 'Year';
+
+	maxPermittedPrintUsagePeriod = lowerCaseEnumTimePeriods.includes(maxPermittedPrintUsagePeriod) ? maxPermittedPrintUsagePeriod.charAt(0).toUpperCase() + maxPermittedPrintUsagePeriod.slice(1) : maxPermittedPrintUsagePeriod;
+	maxPermittedOnlineUsagePeriod = lowerCaseEnumTimePeriods.includes(maxPermittedOnlineUsagePeriod) ? maxPermittedOnlineUsagePeriod.charAt(0).toUpperCase() + maxPermittedOnlineUsagePeriod.slice(1) : maxPermittedOnlineUsagePeriod;
+
 	return {
 		asset_class: item.assetType,
 		asset_id: item.assetId,
 		asset_type: item.assetName,
 		content_type: ASSET_TYPE_TO_CONTENT_TYPE[item.assetName],
 		product: item.productName,
-		print_usage_period: item.maxPermittedPrintUsagePeriod || 'Year',
+		print_usage_period: maxPermittedPrintUsagePeriod,
 		print_usage_limit: item.maxPermittedPrintUsage,
-		online_usage_period: item.maxPermittedOnlineUsagePeriod || 'Year',
+		online_usage_period: maxPermittedOnlineUsagePeriod,
 		online_usage_limit: item.maxPermittedOnlineUsage,
 		embargo_period: item.embargoPeriod || 0,
 		content_set: item.contentSet,


### PR DESCRIPTION
### Description
If the contract data is coming all lowercase from Salesforce, capitalize the first letter before saving to the DB. This is because of the enum_time_period in next-syndication-db-schema, which only accepts uppercase: https://github.com/Financial-Times/next-syndication-db-schema/blob/main/schema.syndication.base/type/enum_time_period.sql

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-2118)

### What is the new version number in package.json?
<!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->
