### PR TITLE
ACC-2137 Add base tables to backup

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -56,11 +56,14 @@
         - content_es
         - contract_asset_content_set
         - contract_asset_items
+        - contract_assets
+        - contract_asset_content_areas
         - contract_asset_register
         - contract_users
         - contracts
         - contributor_purchase
         - download_history
+        - legacy_download_history
         - migrated_users
         - save_history
         - users


### PR DESCRIPTION
### Description
All the base tables need to be added to the backups for the computed tables to be restored properly.


### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-2137)