### PR TITLE
ACC-2132 Remove PII Data from Postgres logs

### DIFF
--- a/server/lib/download/index.js
+++ b/server/lib/download/index.js
@@ -31,10 +31,7 @@ module.exports = exports = (config) => {
 					user_agent: req.get('user-agent')
 				},
 				user: {
-					email: user.email,
-					first_name: user.first_name,
-					id: user.user_id,
-					surname: user.surname
+					id: user.user_id
 				}
 			}
 		});


### PR DESCRIPTION
### Description
The original purpose of the ticket was to stop sending so many Postgres logs every time a user downloads an article. However, while at it, we also discovered some of these logs contained PII data. **This PR removes the PII data from the logs.**

**Investigation**:
We discovered that the 600k Postgres logs happen only when a user downloads an article the first time. If they download the same article a second time then the number of logs is reduced to about 1k. 

We believe this is happening because of this trigger: https://github.com/Financial-Times/next-syndication-db-schema/blob/main/schema.syndication.computed/trigger/contract_asset_register_data.sql#L25

this is the first log that shows up when the series of 600k logs occurs:
2022-12-19T15:07:22.000000+00:00 app[postgres.2622403]: [WHITE] [15-1]  sql_error_code = 01000 time_ms = "2022-12-19 15:07:22.762 UTC" pid="287196" proc_start_time="2022-12-19 15:07:22 UTC" session_id="63a07e2a.461dc" vtid="8/78610" tid="18503622" log_line="1" database="d2iali291c8ihs" connection_source="89.131.209.60(53316)" user="u9oq1lm8japepg" application_name="[unknown]" WARNING:  ################# UPSERT: FAILED INSERT syndication.contract_asset_register_data => 23505: contract_asset_register_data_pkey; (CA-00001558,"FT Article",article,0,10000000,100,9997398,"{""total"": 2502}","[{""product"": ""FT Article"", ""addendums"": [], ""asset_type"": ""FT Article"", ""asset_class"": ""New"", ""content_set"": [""FT.com"", ""Spanish content"", ""Spanish Weekend""], ""contract_id"": ""CA-00001558"", ""content_type"": ""article"", ""last_modified"": ""2022-12-19T13:26:29.356246+00:00"", ""embargo_period"": 0, ""contract_asset_id"":

In order to be able to fiddle with the postgres logs/warnings being sent, it seems like we need to fiddle with the DB schema. So we would need to create a replicate DB of the production DB in heroku and create a SQS queue for it. Then, we would need to run `next-syndication-api` locally and map it to the DB replica which would have its own SQS queue. We would then be able to change the schema and monitor how the logs change.

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-2132)
