### PR TITLE
ACC-2159: add computed tables to BackUp

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -67,6 +67,14 @@
         - migrated_users
         - save_history
         - users
+        - contract_asset_data
+        - contract_asset_data_downloaded_counts
+        - contract_asset_item_data
+        - contract_asset_register_data
+        - contract_data
+        - contract_unique_downloads
+        - downloads
+        - saved_items
 
   DEFAULT_DOWNLOAD_FORMAT: docx
   DEFAULT_DOWNLOAD_LANGUAGE: en

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.7",
+  "version": "0.41.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.7",
+  "version": "0.41.8",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",


### PR DESCRIPTION
### Description
The DB restore that we are getting from next-syndication-api backups by following these steps: https://github.com/Financial-Times/next-syndication-db-schema#setting-up-the-db - Connect your Github account is different from the one in production by 83 rows in the contract_asset_data_downloaded_counts table. 

### Ticket
[ACC-21-50](https://financialtimes.atlassian.net/browse/ACC-2159)
### What is the new version number in package.json?
0.41.8

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
pending