### PR TITLE
ACC-2208 enhance NullApexResponse error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.8",
+  "version": "0.41.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "0.41.7",
+      "version": "0.41.9",
       "hasInstallScript": true,
       "dependencies": {
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.8",
+  "version": "0.41.9",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/server/lib/get-salesforce-contract-by-id.js
+++ b/server/lib/get-salesforce-contract-by-id.js
@@ -64,7 +64,7 @@ module.exports = exports = async (contractId, dontThrow) => {
 			return null;
 		}
 
-		throw new Error('NullApexResponse');
+		throw new Error('NullApexResponse', {furtherDetails: 'In the past this was associated with incidents where a given contract users cannot see the Syndication icons. A quick solution is for the B2B Operations Team to manually regenerate the licence via Salesforce', apexRes});
 	}
 	catch (error) {
 		log.error(error);


### PR DESCRIPTION
### Description
We had a small incident https://financialtimes.slack.com/archives/C042NBBTM/p1673609082333779 where users on a specific contract couldn't see the Syndication Icons. All we had was a bunch of `NullApexResponse`. 
Originally we thought that the best thing to do was to add a default value to `dontThrow` (which is defined as an argument of this function, but isn't actually used in any places where the function is called) - but there wasn't a clear answer as to what the default should be. 

So what we're doing is enhancing the error so that it's a bit clearer as to what's happening "under the hood" and offer a quick fix to whoever is looking at the logs. Hopefully if and when we actually get to see `NullApexResponse` again, we will also have more information to allow us to make an informed decision as to how to improve our code. 

### Ticket
https://financialtimes.atlassian.net/browse/ACC-2208 - the ticket is about setting the default value, but we decided not to do that, but use the ticket to enhance the error. 

### What is the new version number in package.json?
0.41.9

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/128