### PR TITLE
ACC-2207: update runbook

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -114,6 +114,25 @@ If this is a problem for all Syndication users it could be:
 
 We can check the details of a specific contract and the user status page to begin to debug the issue. It is useful to tail the heroku logs for next-syndication-api while doing this so you can also see database activity with `heroku logs --app ft-next-syndication-api --tail --num 0 `
 
+This could be caused too by the user already existing in the database with their old ID and the same email address. The database
+uses the user ID as the primary key and the email address as a unique index. Therefore, when you try to add a new user
+id with an email address that already exists, it will fail. The system isn’t designed to handle user IDs changing.This
+can be fixed by making a backup, running a sql transaction script against the database, and then testing that all
+references to the old ID had disappeared.
+
+```shell
+ BEGIN;
+    UPDATE syndication.users SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.contract_users SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.downloads SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.contract_unique_downloads SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.contributor_purchase SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.save_history SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.saved_items SET user_id='newId' WHERE user_id='oldId';
+    UPDATE syndication.migrated_users SET user_id='newId' WHERE user_id='oldId';
+ COMMIT;  
+```
+
 ### Contract details not refreshing
 
 First go to the `/syndication/contract-status?contract_id=${CONTRACT_NUMBER_HAVING_ISSUES}` and look for the `last_updated` property. You will need to have your 'role' set to 'superuser' or 'superdooperuser' in the syndication users table for this to return anything other than the contract you are on.


### PR DESCRIPTION
### Description
we’ve had [a report](https://financialtimes.slack.com/archives/C042NBBTM/p1674485188998109) that a user is unable to access the syndication tools in their browser.

we solved executing a script against syndication database to update the new guid of the user and we update the runbook doc to help with this possible issue in the future

### Ticket
[ACC-2207](https://financialtimes.atlassian.net/browse/ACC-2207)


[ACC-2207]: https://financialtimes.atlassian.net/browse/ACC-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ