### PR TITLE
ACC-2264: prevent error about possible null errors in the assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.9",
+  "version": "0.41.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "0.41.9",
+      "version": "0.41.10",
       "hasInstallScript": true,
       "dependencies": {
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.9",
+  "version": "0.41.10",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -61,7 +61,7 @@ function decorateContract(contract, hasGraphics = false) {
 		} else {
 			log.info('NULL ASSETS', {
 				asset: asset,
-				contract: contract
+				contract_id: contract.contract_id
 			});
 		}
 

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -58,6 +58,11 @@ function decorateContract(contract, hasGraphics = false) {
 					asset.hasAddendums = true;
 				}
 			});
+		} else {
+			log.info('NULL ASSETS', {
+				asset: asset,
+				contract: contract
+			});
 		}
 
 		return acc;

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -50,13 +50,15 @@ function decorateContract(contract, hasGraphics = false) {
 		acc[asset.asset_type] =
 		acc[asset.content_type] = asset;
 
-		asset.assets.forEach(item => {
-			item.content = (Array.isArray(item.content_set)) ? item.content_set.join('; ') : '';
+		if(Array.isArray(asset.assets)) {
+			asset.assets.forEach(item => {
+				item.content = (Array.isArray(item.content_set)) ? item.content_set.join('; ') : '';
 
-			if (Array.isArray(item.addendums) && item.addendums.length) {
-				asset.hasAddendums = true;
-			}
-		});
+				if (Array.isArray(item.addendums) && item.addendums.length) {
+					asset.hasAddendums = true;
+				}
+			});
+		}
 
 		return acc;
 	}, {});

--- a/server/middleware/get-contract-by-id-from-session.js
+++ b/server/middleware/get-contract-by-id-from-session.js
@@ -27,7 +27,7 @@ module.exports = exports = async (req, res, next) => {
 					['spanish content', 'spanish_content'],
 					['spanish weekend', 'spanish_weekend']
 				].forEach(([content_area, property]) => {
-					acc[property] = acc[property] || assets.some(({ content }) => content.toLowerCase().includes(content_area));
+					acc[property] = acc[property] || (assets && assets.some(({ content }) => content && content.toLowerCase().includes(content_area)));
 				});
 
 				return acc;


### PR DESCRIPTION
### Description
Due to an error with salesforce data, there may be cases in which we receive the assets of a contract as null, causing the code to break and not allow users to enter.
[Slack](https://financialtimes.slack.com/archives/C3LRB6JCE/p1678197718180599)

### Ticket
[ACC-2264](https://financialtimes.atlassian.net/browse/ACC-2264)
### What is the new version number in package.json?
0.41.10
### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->


[ACC-2264]: https://financialtimes.atlassian.net/browse/ACC-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ