### PR TITLE
ACC-2270: add api test for download content syndication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.11",
+  "version": "0.41.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "0.41.11",
+      "version": "0.41.12",
       "hasInstallScript": true,
       "dependencies": {
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@financial-times/eslint-config-next": "^6.0.0",
         "@financial-times/n-test": "^4.0.0",
         "chai": "^4.0.2",
+        "chai-http": "^4.3.0",
         "check-engine": "^1.10.1",
         "coveralls": "^2.13.1",
         "dotcom-tool-kit": "^2.3.5",
@@ -1720,6 +1721,18 @@
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -1763,6 +1776,16 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
+      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -3076,6 +3099,69 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-http": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.3.0.tgz",
+      "integrity": "sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "4",
+        "@types/superagent": "^3.8.3",
+        "cookiejar": "^2.1.1",
+        "is-ip": "^2.0.0",
+        "methods": "^1.1.2",
+        "qs": "^6.5.1",
+        "superagent": "^3.7.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-http/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/chai-http/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/chai-http/node_modules/superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/chainsaw": {
@@ -7041,6 +7127,15 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
+    "node_modules/ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7321,6 +7416,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
+      "dev": true,
+      "dependencies": {
+        "ip-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-lambda": {
@@ -20335,6 +20442,18 @@
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -20377,6 +20496,16 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
+      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "4.0.2",
@@ -21393,6 +21522,61 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-http": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.3.0.tgz",
+      "integrity": "sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "4",
+        "@types/superagent": "^3.8.3",
+        "cookiejar": "^2.1.1",
+        "is-ip": "^2.0.0",
+        "methods": "^1.1.2",
+        "qs": "^6.5.1",
+        "superagent": "^3.7.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "superagent": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
+          }
+        }
       }
     },
     "chainsaw": {
@@ -24526,6 +24710,12 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -24732,6 +24922,15 @@
             "path-is-inside": "^1.0.1"
           }
         }
+      }
+    },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.0.0"
       }
     },
     "is-lambda": {

--- a/package.json
+++ b/package.json
@@ -33,18 +33,19 @@
     "xmldom": "^0.6.0"
   },
   "devDependencies": {
-    "dotcom-tool-kit": "^2.3.5",
     "@dotcom-tool-kit/backend-app": "^2.0.11",
-    "@dotcom-tool-kit/mocha": "^2.1.5",
-    "@dotcom-tool-kit/husky-npm": "^2.2.0",
-    "@dotcom-tool-kit/npm": "^2.0.9",
-    "@financial-times/n-test": "^4.0.0",
     "@dotcom-tool-kit/eslint": "^2.2.1",
-    "@financial-times/eslint-config-next": "^6.0.0",
+    "@dotcom-tool-kit/husky-npm": "^2.2.0",
+    "@dotcom-tool-kit/mocha": "^2.1.5",
+    "@dotcom-tool-kit/npm": "^2.0.9",
     "@dotcom-tool-kit/secret-squirrel": "^1.0.7",
+    "@financial-times/eslint-config-next": "^6.0.0",
+    "@financial-times/n-test": "^4.0.0",
     "chai": "^4.0.2",
+    "chai-http": "^4.3.0",
     "check-engine": "^1.10.1",
     "coveralls": "^2.13.1",
+    "dotcom-tool-kit": "^2.3.5",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
@@ -62,7 +63,6 @@
     "sinon-chai": "^3.2.0",
     "snyk": "^1.996.0",
     "unzipper": "^0.10.11"
-
   },
   "nyc": {
     "exclude": [
@@ -122,7 +122,7 @@
     "lint-fix": "eslint . --ext .js --fix",
     "killall": "./node_modules/.bin/pm2 stop all && ./node_modules/.bin/pm2 kill",
     "monit": "./node_modules/.bin/pm2 monit",
-    "unit-test" : "IGNORE_A11Y=true  NEW_SYNDICATION_USERS=testUserUuid1,testUserUuid2  NEW_SYNDICATION_USERS_AWAITING=testUserUuid3,testUserUuid4 NODE_ENV=test node ./node_modules/.bin/mocha --full-trace --harmony --recursive --slow 15000 --sort --timeout 30000 test/"
+    "unit-test": "IGNORE_A11Y=true  NEW_SYNDICATION_USERS=testUserUuid1,testUserUuid2  NEW_SYNDICATION_USERS_AWAITING=testUserUuid3,testUserUuid4 NODE_ENV=test node ./node_modules/.bin/mocha --full-trace --harmony --recursive --slow 15000 --sort --timeout 30000 test/"
   },
   "config": {},
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.11",
+  "version": "0.41.12",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/test/api/download-by-content-id-api.spec.js
+++ b/test/api/download-by-content-id-api.spec.js
@@ -1,0 +1,58 @@
+process.env.SESSION_PUBLIC_KEY = 'session_public_key';
+process.env.FT_GRAPHITE_KEY= 'graphite_key';
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../../server/app');
+const path = require('path');
+const sinon = require('sinon');
+
+const { TEST: { FIXTURES_DIRECTORY } } = require('config');
+const enrich = require('../../server/lib/enrich');
+const getContentById = require('../../server/lib/get-content-by-id');
+
+chai.use(chaiHttp);
+const expect = chai.expect;
+
+const CONTENT_ID = '42ad255a-99f9-11e7-b83c-9588e51488a0';
+const FILENAME = 'test.docx';
+
+const contentJSON = require(path.resolve(`${FIXTURES_DIRECTORY}/content/${CONTENT_ID}.json`));
+const enrichedContent = enrich(contentJSON, {
+	download_formats: {
+		abc: 'docx'
+	},
+	allowed: {
+		rich_articles: false
+	}
+});
+
+describe('Download By Content Id', () => {
+
+	let getContentStub;
+
+	beforeEach(() => {
+		getContentStub = sinon.stub(getContentById, 'getContentById');
+	});
+
+	afterEach(() => {
+		getContentStub.restore();
+	});
+
+	it('should stream the download', async () => {
+		getContentStub.resolves(enrichedContent);
+
+		const res = await chai.request(app)
+			.get(`/syndication/download/${CONTENT_ID}`)
+			.query({ format: 'docx' })
+			.set('Cookie', 'FTSession=FTSession;spoor-id=spoor-id');
+
+		expect(res).to.have.status(200);
+		expect(res).to.have.header('content-type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+		expect(res).to.have.header('content-disposition', `attachment; filename="${FILENAME}"`);
+		expect(res).to.have.header('x-accel-buffering', 'no');
+		expect(res).to.have.header('cache-control', 'no-cache, no-store, must-revalidate');
+		expect(res).to.have.header('pragma', 'no-cache');
+		expect(res).to.have.header('expires', '0');
+	});
+});


### PR DESCRIPTION
### Description
The API test should check that when the user clicks on “downloaded items”, they can click on “Download” and a download will start

### Ticket
[ACC-2270](https://financialtimes.atlassian.net/browse/ACC-2270)
### What is the new version number in package.json?
0.41.12

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->


[ACC-2270]: https://financialtimes.atlassian.net/browse/ACC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ