### PR TITLE
Replace Sentry with Reliability Kit Crash Handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.12",
+  "version": "0.41.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "0.41.12",
+      "version": "0.41.14",
       "hasInstallScript": true,
       "dependencies": {
+        "@dotcom-reliability-kit/crash-handler": "^2.1.1",
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
         "@financial-times/n-es-client": "4.1.0",
-        "@financial-times/n-express": "26.3.15",
+        "@financial-times/n-express": "^27.5.0",
         "@financial-times/n-mask-logger": "7.2.0",
         "@financial-times/session-decoder-js": "1.3.1",
         "ajv": "^6.0.0",
@@ -485,13 +486,67 @@
         "npm": "7.x || 8.x"
       }
     },
-    "node_modules/@dotcom-reliability-kit/errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.3.0.tgz",
-      "integrity": "sha512-sG6IHaAzsV6htgmRzUqhxS0YsJtE5XHXYxga3P1XIir//z3mIMziBXuMHQvrMre1zWLC4D8l7Rrl6J4dGS8pDg==",
+    "node_modules/@dotcom-reliability-kit/crash-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-2.1.1.tgz",
+      "integrity": "sha512-IbmKCK6LPLYMN/7873xA9hkGjcZJnMk2jOANQ4t8BhKejKWkOiZE2wpOovtcUQcD7hFMyMhtpCEMxoe31MSTXg==",
+      "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^2.1.1"
+      },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-2.1.1.tgz",
+      "integrity": "sha512-ZJn+y8qQs5Bai2SBsopHT9E87aMhY31jCRYeQbkSMd/JRjFitjOjRyMAXDG1zVBtmwauX+wEcRKXgqoKgWmgdw==",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.2.0",
+        "@financial-times/n-logger": "^10.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/errors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.1.1.tgz",
+      "integrity": "sha512-oumFLYMo4zsVP7/+CBgJ/z0oOthZAlQxTI3Yn45MjkAtMoq7zasqXGPLVTDZoXgDtkdlUu/OJyTs6G4I1WVKPA==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/log-error": {
@@ -903,38 +958,54 @@
       }
     },
     "node_modules/@financial-times/n-express": {
-      "version": "26.3.15",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-26.3.15.tgz",
-      "integrity": "sha512-EP3AhRPzHkl/Z393amO0n/yJPTOML5EyiFfhvhDM3/no7odvzcNwfVoSHRHGb+iTm4u2AJ9V6A/8HVmxvzQJSQ==",
-      "hasInstallScript": true,
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
+      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^1.2.7",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.6",
+        "@dotcom-reliability-kit/errors": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.0.0",
+        "@financial-times/n-flags-client": "^13.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.2",
-        "next-metrics": "^7.7.0",
+        "n-health": "^10.0.0",
+        "next-metrics": "^9.2.0",
         "semver": "^7.3.7"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-express/node_modules/n-health": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.1.0.tgz",
-      "integrity": "sha512-sbyjssk5qDVApTVkE6NsWizC6Ys8V8mRXaz4zqpYNKW2bT3aJxtSh32X7c7IXs5cvWLMNeDmVDLbki5dXKkxuA==",
-      "hasInstallScript": true,
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
+      "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",
@@ -944,8 +1015,8 @@
         "node-fetch": "^2.6.7"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-fetch": {
@@ -1160,32 +1231,30 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
-      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
-      "hasInstallScript": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
+      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^6.0.1",
+        "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-flags-client/node_modules/n-eager-fetch": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.2.tgz",
-      "integrity": "sha512-iJ0M9kkcwGbM/4M+SqXq/7OR+RG269p82mI9bewgpL0sYCPAhC3bzlXtCGRsfj4Wd8Xx1PN2yCnYXm3lUYpDcQ==",
-      "hasInstallScript": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+      "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
         "npm-prepublish": "^1.2.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-logger": {
@@ -9370,18 +9439,17 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next-metrics": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.7.0.tgz",
-      "integrity": "sha512-UbTJjtbd8e1wifkCetvWPHJEdZAFMFy4HmsX3+y5TnfXWlkaV+UnDl9cQzAyceLZPzPgZsBuw5ogmbQGvAqZjw==",
-      "hasInstallScript": true,
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
+      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/next-tick": {
@@ -19479,10 +19547,46 @@
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.1.0.tgz",
       "integrity": "sha512-GyZkVEpj3VZr9+8Z4D2InEU/xPCnbwPUhC/tvimJW9vxyn6nbjY58qJpHm+VZ+swmaILWEPoCfyLdTpFdG4o3Q=="
     },
+    "@dotcom-reliability-kit/crash-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-2.1.1.tgz",
+      "integrity": "sha512-IbmKCK6LPLYMN/7873xA9hkGjcZJnMk2jOANQ4t8BhKejKWkOiZE2wpOovtcUQcD7hFMyMhtpCEMxoe31MSTXg==",
+      "requires": {
+        "@dotcom-reliability-kit/log-error": "^2.1.1"
+      },
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+          "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
+        },
+        "@dotcom-reliability-kit/log-error": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-2.1.1.tgz",
+          "integrity": "sha512-ZJn+y8qQs5Bai2SBsopHT9E87aMhY31jCRYeQbkSMd/JRjFitjOjRyMAXDG1zVBtmwauX+wEcRKXgqoKgWmgdw==",
+          "requires": {
+            "@dotcom-reliability-kit/app-info": "^2.1.0",
+            "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+            "@dotcom-reliability-kit/serialize-request": "^2.2.0",
+            "@financial-times/n-logger": "^10.3.1"
+          }
+        },
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+        },
+        "@dotcom-reliability-kit/serialize-request": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+          "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
+        }
+      }
+    },
     "@dotcom-reliability-kit/errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.3.0.tgz",
-      "integrity": "sha512-sG6IHaAzsV6htgmRzUqhxS0YsJtE5XHXYxga3P1XIir//z3mIMziBXuMHQvrMre1zWLC4D8l7Rrl6J4dGS8pDg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.1.1.tgz",
+      "integrity": "sha512-oumFLYMo4zsVP7/+CBgJ/z0oOthZAlQxTI3Yn45MjkAtMoq7zasqXGPLVTDZoXgDtkdlUu/OJyTs6G4I1WVKPA=="
     },
     "@dotcom-reliability-kit/log-error": {
       "version": "1.5.1",
@@ -19826,29 +19930,39 @@
       }
     },
     "@financial-times/n-express": {
-      "version": "26.3.15",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-26.3.15.tgz",
-      "integrity": "sha512-EP3AhRPzHkl/Z393amO0n/yJPTOML5EyiFfhvhDM3/no7odvzcNwfVoSHRHGb+iTm4u2AJ9V6A/8HVmxvzQJSQ==",
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
+      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
       "requires": {
-        "@dotcom-reliability-kit/errors": "^1.2.7",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.6",
+        "@dotcom-reliability-kit/errors": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.0.0",
+        "@financial-times/n-flags-client": "^13.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.2",
-        "next-metrics": "^7.7.0",
+        "n-health": "^10.0.0",
+        "next-metrics": "^9.2.0",
         "semver": "^7.3.7"
       },
       "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+        },
+        "@dotcom-reliability-kit/serialize-request": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+          "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
+        },
         "n-health": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.1.0.tgz",
-          "integrity": "sha512-sbyjssk5qDVApTVkE6NsWizC6Ys8V8mRXaz4zqpYNKW2bT3aJxtSh32X7c7IXs5cvWLMNeDmVDLbki5dXKkxuA==",
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
+          "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
           "requires": {
             "@financial-times/n-logger": "^10.2.0",
             "aws-sdk": "^2.6.10",
@@ -20031,19 +20145,19 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
-      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
+      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^6.0.1",
+        "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       },
       "dependencies": {
         "n-eager-fetch": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.2.tgz",
-          "integrity": "sha512-iJ0M9kkcwGbM/4M+SqXq/7OR+RG269p82mI9bewgpL0sYCPAhC3bzlXtCGRsfj4Wd8Xx1PN2yCnYXm3lUYpDcQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+          "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
           "requires": {
             "isomorphic-fetch": "^3.0.0",
             "npm-prepublish": "^1.2.2"
@@ -26507,9 +26621,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next-metrics": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.7.0.tgz",
-      "integrity": "sha512-UbTJjtbd8e1wifkCetvWPHJEdZAFMFy4HmsX3+y5TnfXWlkaV+UnDl9cQzAyceLZPzPgZsBuw5ogmbQGvAqZjw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
+      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "0.41.14",
   "private": true,
   "dependencies": {
+    "@dotcom-reliability-kit/crash-handler": "^2.1.1",
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
     "@financial-times/n-es-client": "4.1.0",
-    "@financial-times/n-express": "26.3.15",
+    "@financial-times/n-express": "^27.5.0",
     "@financial-times/n-mask-logger": "7.2.0",
     "@financial-times/session-decoder-js": "1.3.1",
     "ajv": "^6.0.0",

--- a/server/app-dl.js
+++ b/server/app-dl.js
@@ -22,6 +22,9 @@ const getUserAccessAuthToken = require('./middleware/get-user-access-auth-token'
 const getSyndicationLicenceForUser = require('./middleware/get-syndication-licence-for-user');
 const getUserProfile = require('./middleware/get-user-profile');
 const routeMaintenanceMode = require('./middleware/route-maintenance-mode');
+const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
+
+registerCrashHandler();
 
 const app = module.exports = express({
 	systemCode: 'next-syndication-dl',

--- a/server/app.js
+++ b/server/app.js
@@ -21,6 +21,9 @@ const getUserProfile = require('./middleware/get-user-profile');
 const isSyndicationUser = require('./middleware/is-syndication-user');
 const masquerade = require('./middleware/masquerade');
 const routeMaintenanceMode = require('./middleware/route-maintenance-mode');
+const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
+
+registerCrashHandler();
 
 const app = module.exports = express({
 	systemCode: 'next-syndication-api',


### PR DESCRIPTION
Part of [CPREL-649](https://financialtimes.atlassian.net/browse/CPREL-649). The n-express update in this PR is safe as it drops Node.js 14 support and disables Sentry by default.


[CPREL-649]: https://financialtimes.atlassian.net/browse/CPREL-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ