### PR TITLE
chore:Alignment of package.json version and release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "0.41.14",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "0.41.14",
+      "version": "1.2.0",
       "dependencies": {
         "@dotcom-reliability-kit/crash-handler": "^2.1.1",
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "0.41.14",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
I have noticed there are inconsistent versions in the release package.json and release version. This PR aimed at aligning the package.json version to align with the release version for consistency going forward


### What is the new version number in package.json?
<!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
[DL PR](https://github.com/Financial-Times/next-syndication-dl/pull/141)
