### PR TITLE
ACC-2510: add current period start and endate for multiyears contracts

### DIFF
--- a/db/pg/column_mappings/contracts.js
+++ b/db/pg/column_mappings/contracts.js
@@ -11,11 +11,11 @@ module.exports = exports = {
 			cite: 'endDate',
 			id: 'end_date'
 		}, {
-			cite: 'currentPeriodStartDate',
-			id: 'current_period_start_date'
+			cite: 'currentStartDate',
+			id: 'current_start_date'
 		}, {
-			cite: 'currentPeriodEndDate',
-			id: 'current_period_end_date'
+			cite: 'currentEndDate',
+			id: 'current_end_date'
 		}, {
 			cite: 'startDate',
 			id: 'start_date'

--- a/db/pg/column_mappings/contracts.js
+++ b/db/pg/column_mappings/contracts.js
@@ -1,86 +1,92 @@
 'use strict';
 
-const { ASSET_TYPE_TO_CONTENT_TYPE } = require('config');
+const {ASSET_TYPE_TO_CONTENT_TYPE} = require('config');
 
 module.exports = exports = {
 	clean: true,
 	items: [{
-		cite: 'contractNumber',
-		id: 'contract_id'
-	}, {
-		cite: 'endDate',
-		id: 'end_date'
-	}, {
-		cite: 'startDate',
-		id: 'start_date'
-	}, {
-		cite: 'contributor',
-		id: 'contributor_content'
-	}, {
-		cite: 'licenceeName',
-		id: 'licencee_name'
-	}, {
-		cite: 'clientPublications',
-		id: 'client_publications'
-	}, {
-		cite: 'clientWebsite',
-		id: 'client_website'
-	}, {
-		cite: 'ownerEmail',
-		id: 'owner_email'
-	}, {
-		cite: 'ownerName',
-		id: 'owner_name'
-	}, {
-		cite: 'assets',
-		clean: true,
-		id: 'assets',
-		items: [{
-			cite: 'assetType',
-			default: 'New',
-			id: 'asset_class'
+			cite: 'contractNumber',
+			id: 'contract_id'
 		}, {
-			cite: 'assetName',
-			id: 'asset_type'
+			cite: 'endDate',
+			id: 'end_date'
 		}, {
-			delete: false,
-			cite: 'asset_type',
-			id: 'content_type',
-			transform: (val) => ASSET_TYPE_TO_CONTENT_TYPE[val]
+			cite: 'currentPeriodStartDate',
+			id: 'current_period_start_date'
 		}, {
-			cite: 'productName',
-			id: 'product'
+			cite: 'currentPeriodEndDate',
+			id: 'current_period_end_date'
 		}, {
-			cite: 'maxPermittedPrintUsagePeriod',
-			id: 'print_usage_period'
+			cite: 'startDate',
+			id: 'start_date'
 		}, {
-			cite: 'maxPermittedPrintUsage',
-			id: 'print_usage_limit'
+			cite: 'contributor',
+			id: 'contributor_content'
 		}, {
-			cite: 'maxPermittedOnlineUsagePeriod',
-			id: 'online_usage_period'
+			cite: 'licenceeName',
+			id: 'licencee_name'
 		}, {
-			cite: 'maxPermittedOnlineUsage',
-			id: 'online_usage_limit'
+			cite: 'clientPublications',
+			id: 'client_publications'
 		}, {
-			cite: 'embargoPeriod',
-			id: 'embargo_period'
+			cite: 'clientWebsite',
+			id: 'client_website'
 		}, {
-			cite: 'content',
-			id: 'content' //,
+			cite: 'ownerEmail',
+			id: 'owner_email'
+		}, {
+			cite: 'ownerName',
+			id: 'owner_name'
+		}, {
+			cite: 'assets',
+			clean: true,
+			id: 'assets',
+			items: [{
+				cite: 'assetType',
+				default: 'New',
+				id: 'asset_class'
+			}, {
+				cite: 'assetName',
+				id: 'asset_type'
+			}, {
+				delete: false,
+				cite: 'asset_type',
+				id: 'content_type',
+				transform: (val) => ASSET_TYPE_TO_CONTENT_TYPE[val]
+			}, {
+				cite: 'productName',
+				id: 'product'
+			}, {
+				cite: 'maxPermittedPrintUsagePeriod',
+				id: 'print_usage_period'
+			}, {
+				cite: 'maxPermittedPrintUsage',
+				id: 'print_usage_limit'
+			}, {
+				cite: 'maxPermittedOnlineUsagePeriod',
+				id: 'online_usage_period'
+			}, {
+				cite: 'maxPermittedOnlineUsage',
+				id: 'online_usage_limit'
+			}, {
+				cite: 'embargoPeriod',
+				id: 'embargo_period'
+			}, {
+				cite: 'content',
+				id: 'content' //,
 //			transform: (val) => typeof val === 'string' ? val.split(';').map(item => item.trim()) : Array.isArray(val) ? val : []
-		}, {
-			cite: '../articleLimit',
-			condition: (item) => item.asset_type === 'FT Article',
-			id: 'download_limit'
-		}, {
-			cite: '../podcastLimit',
-			condition: (item) => item.asset_type === 'Podcast',
-			id: 'download_limit'
-		}, {
-			cite: '../videoLimit',
-			condition: (item) => item.asset_type === 'Video',
-			id: 'download_limit'
+			}, {
+				cite: '../articleLimit',
+				condition: (item) => item.asset_type === 'FT Article',
+				id: 'download_limit'
+			}, {
+				cite: '../podcastLimit',
+				condition: (item) => item.asset_type === 'Podcast',
+				id: 'download_limit'
+			}, {
+				cite: '../videoLimit',
+				condition: (item) => item.asset_type === 'Video',
+				id: 'download_limit'
+			}]
 		}]
-	}]
 };

--- a/db/table_schemas/contracts.js
+++ b/db/table_schemas/contracts.js
@@ -27,6 +27,8 @@ module.exports = exports = {
 		{ AttributeAlias: 'owner_name', AttributeName: 'ownerName', AttributeType: 'S' },
 		{ AttributeAlias: 'owner_email', AttributeName: 'ownerEmail', AttributeType: 'S' },
 		{ AttributeAlias: 'last_updated', AttributeName: 'last_updated', AttributeType: 'S' },
+		{ AttributeAlias: 'current_period_start_date', AttributeName: 'currentPeriodStartDate', AttributeType: 'S' },
+		{ AttributeAlias: 'current_period_end_date', AttributeName: 'currentPeriodEndDate', AttributeType: 'S' },
 		{
 			AttributeAlias: 'assets', AttributeName: 'assets', AttributeType: 'L',
 			AttributeDefinitions: [

--- a/db/table_schemas/contracts.js
+++ b/db/table_schemas/contracts.js
@@ -27,8 +27,8 @@ module.exports = exports = {
 		{ AttributeAlias: 'owner_name', AttributeName: 'ownerName', AttributeType: 'S' },
 		{ AttributeAlias: 'owner_email', AttributeName: 'ownerEmail', AttributeType: 'S' },
 		{ AttributeAlias: 'last_updated', AttributeName: 'last_updated', AttributeType: 'S' },
-		{ AttributeAlias: 'current_period_start_date', AttributeName: 'currentPeriodStartDate', AttributeType: 'S' },
-		{ AttributeAlias: 'current_period_end_date', AttributeName: 'currentPeriodEndDate', AttributeType: 'S' },
+		{ AttributeAlias: 'current_start_date', AttributeName: 'currentStartDate', AttributeType: 'S' },
+		{ AttributeAlias: 'current_end_date', AttributeName: 'currentEndDate', AttributeType: 'S' },
 		{
 			AttributeAlias: 'assets', AttributeName: 'assets', AttributeType: 'L',
 			AttributeDefinitions: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -40,8 +40,8 @@ module.exports = exports = async (req, res, next) => {
 				contract_data.last_updated = new Date();
 				if (contract_data.orders) {
 					const activeOrder = contract_data.orders.find(order => order.status === 'Active');
-					contract_data.current_period_start_date = new Date(activeOrder.startDate);
-					contract_data.current_period_end_date = new Date(activeOrder.endDate);
+					contract_data.current_start_date = new Date(activeOrder.startDate);
+					contract_data.current_end_date = new Date(activeOrder.endDate);
 				}
 				contract_data = pgMapColumns(contract_data, contractsColumnMappings);
 

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -38,6 +38,11 @@ module.exports = exports = async (req, res, next) => {
 			if (req.query.save !== '0') {
 				let contract_data = reformatSalesforceContract(JSON.parse(JSON.stringify(contract)));
 				contract_data.last_updated = new Date();
+				if (contract_data.orders) {
+					const activeOrder = contract_data.orders.find(order => order.status === 'Active');
+					contract_data.current_period_start_date = new Date(activeOrder.startDate);
+					contract_data.current_period_end_date = new Date(activeOrder.endDate);
+				}
 				contract_data = pgMapColumns(contract_data, contractsColumnMappings);
 
 				const db = await pg();

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -106,6 +106,11 @@ module.exports = exports = async (contractId, locals = {}) => {
 	if (contract.success === true) {
 		contract = reformatSalesforceContract(contract);
 		contract.last_updated = new Date();
+		if (contract.orders) {
+			const activeOrder = contract.orders.find(order => order.status === 'Active');
+			contract.current_start_date = new Date(activeOrder.startDate);
+			contract.current_end_date = new Date(activeOrder.endDate);
+		}
 
 		contract = pgMapColumns(contract, contractsColumnMappings);
 


### PR DESCRIPTION
### Description
We need to add new current period date columns in contracts table using the salesforce new payload fields (orders).

This way we can modify after the query that counts the “current_downloads” in contract_asset_register_data and contract_asset_data tables in syndication database.

we need to check that this “current_period_start_date” and “current_period_end_date” are updated when the current period change.

We have a 24h cronjob that calls the salesforce endpoint and we should check if the current period has changed checking the period status, we should always update this columns with the dates of the current period to keep it updated. 
### Ticket
[ACC-2510](https://financialtimes.atlassian.net/browse/ACC-2510)
### What is the new version number in package.json?
1.3.0

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
pending

[ACC-2510]: https://financialtimes.atlassian.net/browse/ACC-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ