### PR TITLE
ACC-2702 Fix user access token error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",

--- a/server/middleware/get-user-access-auth-token.js
+++ b/server/middleware/get-user-access-auth-token.js
@@ -29,10 +29,11 @@ module.exports = exports = async (req, res, next) => {
 				'cookie': req.headers.cookie,
 				'content-type': 'application/json'
 			},
+			redirect: 'manual',
 			method: 'get'
 		});
-
-		const authQuery = qs.parse(authRes.url.split('#').pop());
+		const authResLocation = authRes.headers.get('location');
+		const authQuery = qs.parse(authResLocation.split('#').pop());
 
 		if (!authQuery.access_token) {
 			throw new ReferenceError(`No User Access Token returned for ${URI}`);


### PR DESCRIPTION
### Description
The automatic redirect would return a url of `www.ft.com` without the `auth_token`. Setting redirect to `manual` gives us the correct url location in the headers with the `auth_token`. This fix addresses the [No User Access Token errors ](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D*next-syndication*%20level%3Derror&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-24h&latest=now&sid=1696338500.32133489) being logged

### Ticket
https://financialtimes.atlassian.net/browse/ACC-2702

### What is the new version number in package.json?
1.4.1

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
TBD.. 1.4.0 needs to be released first
