### PR TITLE
Add a fallback option for authRes.location to avoid error

### DIFF
--- a/server/middleware/get-user-access-auth-token.js
+++ b/server/middleware/get-user-access-auth-token.js
@@ -32,7 +32,7 @@ module.exports = exports = async (req, res, next) => {
 			redirect: 'manual',
 			method: 'get'
 		});
-		const authResLocation = authRes.headers.get('location');
+		const authResLocation = authRes.headers.get('location') || '';
 		const authQuery = qs.parse(authResLocation.split('#').pop());
 
 		if (!authQuery.access_token) {


### PR DESCRIPTION
### Description
`.split()` method was erroring when `authResLocation` is null

### What is the new version number in package.json?
1.4.2

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/152