### PR TITLE
Setup doppler

### DIFF
--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -1,12 +1,12 @@
 plugins:
-  - '@dotcom-tool-kit/eslint'
-  - '@dotcom-tool-kit/secret-squirrel'
-  - '@dotcom-tool-kit/npm'
-  - '@dotcom-tool-kit/husky-npm'
-  - '@dotcom-tool-kit/mocha'
-  - './toolkit/start'
-  - './toolkit/logs'
-  - '@dotcom-tool-kit/backend-heroku-app'
+  - "@dotcom-tool-kit/eslint"
+  - "@dotcom-tool-kit/secret-squirrel"
+  - "@dotcom-tool-kit/npm"
+  - "@dotcom-tool-kit/husky-npm"
+  - "@dotcom-tool-kit/mocha"
+  - "./toolkit/start"
+  - "./toolkit/logs"
+  - "@dotcom-tool-kit/backend-heroku-app"
 
 hooks:
   test:local:
@@ -20,10 +20,10 @@ hooks:
     - SyndicationAPILogs
 
 options:
-  '@dotcom-tool-kit/mocha': {}
-  '@dotcom-tool-kit/eslint': {}
-  '@dotcom-tool-kit/circleci': { nodeVersion: 18.17-browsers }
-  '@dotcom-tool-kit/heroku':
+  "@dotcom-tool-kit/mocha": {}
+  "@dotcom-tool-kit/eslint": {}
+  "@dotcom-tool-kit/circleci": { nodeVersion: 18.17-browsers }
+  "@dotcom-tool-kit/heroku":
     pipeline: ft-next-syndication-api
     systemCode: next-syndication-api
     scaling:
@@ -31,6 +31,5 @@ options:
         web:
           size: standard-1X
           quantity: 1
-  '@dotcom-tool-kit/vault':
-    team: next
-    app: next-syndication-api
+  "@dotcom-tool-kit/doppler":
+    project: next-syndication-api

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ _NB: There is a common misconception that you need all parts of Syndication to b
 
 ### More information about the syndication system
 
-* [The Syndication Wiki](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120533017/Syndication) explains the system and its architecture, including endpoints and authentication.
-* [Next Wiki](https://github.com/Financial-Times/next/wiki/Syndication) covers GDPR SAR and erasure requests so that people without github access can read it, as it is automatically published to <https://customer-products.in.ft.com/wiki/Syndication>.
-* [Database Credentials & Key Rotation](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120533017/Syndication#database-credentials-and-key-rotation) info related with key rotation in the systems
+- [The Syndication Wiki](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120533017/Syndication) explains the system and its architecture, including endpoints and authentication.
+- [Next Wiki](https://github.com/Financial-Times/next/wiki/Syndication) covers GDPR SAR and erasure requests so that people without github access can read it, as it is automatically published to <https://customer-products.in.ft.com/wiki/Syndication>.
+- [Database Credentials & Key Rotation](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120533017/Syndication#database-credentials-and-key-rotation) info related with key rotation in the systems
+
 ## Installation
 
 ```shell
@@ -30,11 +31,11 @@ _NB: There is a common misconception that you need all parts of Syndication to b
     ~$ cd next-syndication-api
 
     ~$ npm install
-    
+
 
 ```
 
-----
+---
 
 ## Deployment
 
@@ -52,7 +53,7 @@ See [getting started](https://financialtimes.atlassian.net/wiki/spaces/Accounts/
 
 ### Other contracts
 
-If you need to test a specific contract, since all contracts live in the production salesforce environment, in order to test certain contracts locally you will need to use the production `SALESFORCE_*` environment variables rather than the development ones (see Vault).
+If you need to test a specific contract, since all contracts live in the production salesforce environment, in order to test certain contracts locally you will need to use the production `SALESFORCE_*` environment variables rather than the development ones (see Doppler).
 
 In development mode you should be using the FT Staff contract, which is stubbed in `stubs/CA-00001558.json`
 
@@ -62,16 +63,16 @@ In development mode you should be using the FT Staff contract, which is stubbed 
 
 You WILL need:
 
-* to be [set up on a syndication contract](#Setting-yourself-up-on-a-contract)
-* [next-syndication-db-schema](https://github.com/Financial-Times/next-syndication-db-schema) - database schema (see Database dependency below)
-* [pandoc](https://pandoc.org/installing.html) installed on your machine for `/download` to work locally
-  * [What is Pandoc?](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8121221233/Syndication+API+DL+Pandoc+and+pandoc+dpkg)
+- to be [set up on a syndication contract](#Setting-yourself-up-on-a-contract)
+- [next-syndication-db-schema](https://github.com/Financial-Times/next-syndication-db-schema) - database schema (see Database dependency below)
+- [pandoc](https://pandoc.org/installing.html) installed on your machine for `/download` to work locally
+  - [What is Pandoc?](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8121221233/Syndication+API+DL+Pandoc+and+pandoc+dpkg)
 
 You MIGHT need:
 
-* [next-syn-list](https://github.com/Financial-Times/next-syn-list) - front-end app for syndication customers. If you want to work on the pages that users see when they go to `/republishing` you will need this.
-* [n-syndication](https://github.com/Financial-Times/n-syndication) - client-side library for syndication icons and overlays which you can `bower link` to an app (e.g. next-front-page) for local development.
-* [next-syndication-dl](https://github.com/Financial-Times/next-syndication-dl) - downloads app, you are less likely to need to work on this though.
+- [next-syn-list](https://github.com/Financial-Times/next-syn-list) - front-end app for syndication customers. If you want to work on the pages that users see when they go to `/republishing` you will need this.
+- [n-syndication](https://github.com/Financial-Times/n-syndication) - client-side library for syndication icons and overlays which you can `bower link` to an app (e.g. next-front-page) for local development.
+- [next-syndication-dl](https://github.com/Financial-Times/next-syndication-dl) - downloads app, you are less likely to need to work on this though.
 
 ### Database dependency
 
@@ -83,7 +84,7 @@ If you are using postgres in Docker, you will need to edit your `.env` file to s
 
 Once you have set up the projects you want to work on, and want to run all projects easily, you can do so from within the `next-syndication-api`, you will need to:
 
-* update your local [next-router](https://github.com/Financial-Times/next-router)'s `.env` file to include the following:
+- update your local [next-router](https://github.com/Financial-Times/next-router)'s `.env` file to include the following:
 
   ```properties
 
@@ -95,28 +96,29 @@ Once you have set up the projects you want to work on, and want to run all proje
 
   (request will fail on the browser because is an API and it requires `x-api-key` to be present in the request)
 
+  - HOWEVER if you are also running another app like `next-syn-list` or `next-article`, do not run `next-router` at the same time. Those apps run `next-router` by default so you don't need an independent instance. In fact, trying to run an independent instance of `next-router` will stop your local `next-article` app from working.
 
-  * HOWEVER if you are also running another app like `next-syn-list` or `next-article`, do not run `next-router` at the same time. Those apps run `next-router` by default so you don't need an independent instance. In fact, trying to run an independent instance of `next-router` will stop your local `next-article` app from working.
-* `cd` into `next-syndication-api` and `npm start`
-  * This will start the `next-syndication-api`, the associated worker processes and the republishing contract and history pages using [PM2](https://www.npmjs.com/package/pm2), and tail the logs for all HTTP servers/processes.
-* go to [http://local.ft.com:3255/__gtg](http://local.ft.com:3255/__gtg) to confirm the syndication API app is responding
+- `cd` into `next-syndication-api` and `npm start`
+  - This will start the `next-syndication-api`, the associated worker processes and the republishing contract and history pages using [PM2](https://www.npmjs.com/package/pm2), and tail the logs for all HTTP servers/processes.
+- go to [http://local.ft.com:3255/\_\_gtg](http://local.ft.com:3255/__gtg) to confirm the syndication API app is responding
 
-* go to [https://local.ft.com:5050/syndication/user-status](https://local.ft.com:5050/syndication/user-status) to confirm the app is responding with data
-* Optionally, you can also run `npm run monit` to bring up the [PM2 process monitor](https://www.npmjs.com/package/pm2#cpu--memory-monitoring) e.g. for checking out CPU and memory usage.
+- go to [https://local.ft.com:5050/syndication/user-status](https://local.ft.com:5050/syndication/user-status) to confirm the app is responding with data
+- Optionally, you can also run `npm run monit` to bring up the [PM2 process monitor](https://www.npmjs.com/package/pm2#cpu--memory-monitoring) e.g. for checking out CPU and memory usage.
 
 ### Running against prod DB (optional)
+
 To run `next-syndication-api` against prod DB is necessary add to the environment variables defined in `custom-environment-variables.yaml` the prefix `_PROD`.  
 ("DATABASE_NAME_PROD",DATABASE_HOST_PROD","DATABASE_PASSWORD_PROD","DATABASE_PORT_PROD","DATABASE_URL_PROD","DATABASE_USER_NAME_PROD").  
-These variables are already defined in development Vault folder.
+These variables are already defined in development Doppler folder.
 
 ### Running the Syndication UI (optional)
 
-* if you also want to locally test all the `/republishing` pages, `cd` into `next-syn-list` and run `npm run start`
+- if you also want to locally test all the `/republishing` pages, `cd` into `next-syn-list` and run `npm run start`
 
-* if you want to test that the syndication icon buttons work too, install and run [next-article](https://github.com/Financial-Times/next-article) locally.
+- if you want to test that the syndication icon buttons work too, install and run [next-article](https://github.com/Financial-Times/next-article) locally.
 
-  * Make sure to stop any instances of `next-router` you have running before you run `next-article`.
-  * Which syndication icon gets shown for each article depends on the [article data returned from CAPI/ES](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120860920/Syndication+API+article+syndication+permissions)
+  - Make sure to stop any instances of `next-router` you have running before you run `next-article`.
+  - Which syndication icon gets shown for each article depends on the [article data returned from CAPI/ES](https://financialtimes.atlassian.net/wiki/spaces/Accounts/pages/8120860920/Syndication+API+article+syndication+permissions)
 
 ### Restarting
 
@@ -127,9 +129,9 @@ You can stop all pm2 processes with the command `npm run killall`. You can chain
 
 ## Configuration
 
-This project and the [next-syndication-dL](https://github.com/Financial-Times/next-syndication-dl) project both use standard next environment variables for storing secrets in vault.
+This project and the [next-syndication-dL](https://github.com/Financial-Times/next-syndication-dl) project both use standard next environment variables for storing secrets in Doppler.
 
-Though a lot of config for these projects is not secret, so rather than pollute vault with generic configuration, a layer has been added on top of the standard environment variables.
+Though a lot of config for these projects is not secret, so rather than pollute Doppler with generic configuration, a layer has been added on top of the standard environment variables.
 
 Both projects use a library called [config](https://www.npmjs.com/package/config) for which you define a `config/default.yaml` file which can be overlaid by other config files based on naming conventions like `config/${NODE_ENV}.yaml` and/or `config/${require('os').hostname()}.yaml` see the [config module documentation for File Load Order](https://github.com/lorenwest/node-config/wiki/Configuration-Files#file-load-order) for more information.
 
@@ -153,21 +155,21 @@ There is a [JSON export of a Postman collection](doc/syndication-api-postman.jso
 
 To run this, you will need to:
 
-* import the JSON into your Postman app to create the collection
-* set up an Environment in Postman with the following variables
-  * `syndication-api-key`, set to the value of the `SYNDICATION_API_KEY` (see Vault) to run the troubleshooting and workers endpoints
-  * `als-api-key`, set to the value of `ALS_API_KEY` (see Vault) to run the membership API licence details endpoint
-  * `user-id`, set to the value of a user ID already in the users table (recommend your own or another FT staff member's) to run the `db-persist` worker testing endpoint
-* set up `cookie` in Postman request headers for domain `local.ft.com` and get the values for `FTSession` and `FTSession_s` from your ft.com cookie in your browser to pass authentication
+- import the JSON into your Postman app to create the collection
+- set up an Environment in Postman with the following variables
+  - `syndication-api-key`, set to the value of the `SYNDICATION_API_KEY` (see Doppler) to run the troubleshooting and workers endpoints
+  - `als-api-key`, set to the value of `ALS_API_KEY` (see Doppler) to run the membership API licence details endpoint
+  - `user-id`, set to the value of a user ID already in the users table (recommend your own or another FT staff member's) to run the `db-persist` worker testing endpoint
+- set up `cookie` in Postman request headers for domain `local.ft.com` and get the values for `FTSession` and `FTSession_s` from your ft.com cookie in your browser to pass authentication
 
-* Some of the endpoints for example `https://local.ft.com:5050/syndication/contracts/{CONTRAcT_ID}` requires a `x-api-key` set the value of `SYNDICATION_API_KEY` in vault to be the `x-api-key` in postman request headers.(Note: These endpoints won't return the expected response via the browser because they requires `x-api-key`)
+- Some of the endpoints for example `https://local.ft.com:5050/syndication/contracts/{CONTRAcT_ID}` requires a `x-api-key` set the value of `SYNDICATION_API_KEY` in doppler to be the `x-api-key` in postman request headers.(Note: These endpoints won't return the expected response via the browser because they requires `x-api-key`)
 
 ### Important notes
 
-* the endpoint set up to trigger the `db persist` worker will result in dummy data being written to the database, only use when connected to local databases.
-* `backup worker` and `redshift worker` will save output files in a `/development` subfolder of the S3 bucket, the response to postman will time out but you can see success/failure logs in your terminal
-* `reload` usually times out, this only runs `syndication.reload_all()` to refresh the full DB contents
-* `get contract by id` will actually result in the contract record being updated in the database with latest data from Salesforce (unless it is the FT Staff contract which uses a stub), despite being a `GET` request
+- the endpoint set up to trigger the `db persist` worker will result in dummy data being written to the database, only use when connected to local databases.
+- `backup worker` and `redshift worker` will save output files in a `/development` subfolder of the S3 bucket, the response to postman will time out but you can see success/failure logs in your terminal
+- `reload` usually times out, this only runs `syndication.reload_all()` to refresh the full DB contents
+- `get contract by id` will actually result in the contract record being updated in the database with latest data from Salesforce (unless it is the FT Staff contract which uses a stub), despite being a `GET` request
 
 ## Maintenance mode
 
@@ -178,11 +180,13 @@ Conversely, turn it off again to turn maintenance mode off.
 If you want to run the API endpoints in Postman while this flag is on, set a cookie for domain `local.ft.com` in Postman for `next-flags` to override it with `next-flags=syndicationMaintenance%3Aoff`
 
 ## Get Articles To Check Syndication Status
+
 This dev tool was set up after it turned out that the emails notifying the right person that an article written by a freelancer was syndicated were not sent. The emails are really important as freelancers get paid for each instance their article is syndicated. This is a back-up to get this information from [Heroku Dataclips](https://data.heroku.com/dataclips).
 
-Step 1: 
+Step 1:
 
 Run the following query on the Syndication Database. You'll need to set the `time` variables to reflect the time period you need to check.
+
 ```sql
 SELECT *
 FROM syndication.downloads
@@ -192,33 +196,34 @@ AND time <= '2022-05-26'
 
 Step 2:
 
-Download the json file, move it to the dev-tools folder. You will need to change the json file and/or the `const { downloads } = require('../syndicationDownloads');` so that it imports the array correctly (you may need to change the .json file to .js and add `const downloads =` to the start). If you are changing the json file, please be patient - sometimes the files are huge and can take minutes to save the change. 
+Download the json file, move it to the dev-tools folder. You will need to change the json file and/or the `const { downloads } = require('../syndicationDownloads');` so that it imports the array correctly (you may need to change the .json file to .js and add `const downloads =` to the start). If you are changing the json file, please be patient - sometimes the files are huge and can take minutes to save the change.
 
 Step 3:
 In your terminal go to dev-tools folder. Set the ES access and secret access keys as described in the [n-es-client readme](https://github.com/Financial-Times/n-es-client#installation). Run `node getArticlesToCheckSyndicationStatus.js`. This will output a `syndicationBackpayWithNames.json` file, which will be an array of objects.
 
 An example of output:
+
 ```json
 [
-	{
-		"canBeSyndicated": "withContributorPayment",
-		"id": "60084cef-9c34-4d12-8407-ea7007f0054e",
-		"title": "Nigeria’s Afrobeats superstars take on the world",
-		"byline": "Ayodeji Rotinwa",
-		"syndicationDetails": [
-			{
-				"uuid": "userID-user1",
-				"downloadTimestamp": "2020-10-30 11:09:17.125+00",
-				"syndicatedBy": "email-address-of-the-user",
-				"contract": "contract-this-user-is-on"
-			},
-			{
-				"uuid": "userID-user1",
-				"downloadTimestamp": "2020-10-30 11:09:17.452+00",
-				"syndicatedBy": "email-address-of-the-user",
-				"contract": "contract-this-user-is-on"
-			}
-		]
-	},
+  {
+    "canBeSyndicated": "withContributorPayment",
+    "id": "60084cef-9c34-4d12-8407-ea7007f0054e",
+    "title": "Nigeria’s Afrobeats superstars take on the world",
+    "byline": "Ayodeji Rotinwa",
+    "syndicationDetails": [
+      {
+        "uuid": "userID-user1",
+        "downloadTimestamp": "2020-10-30 11:09:17.125+00",
+        "syndicatedBy": "email-address-of-the-user",
+        "contract": "contract-this-user-is-on"
+      },
+      {
+        "uuid": "userID-user1",
+        "downloadTimestamp": "2020-10-30 11:09:17.452+00",
+        "syndicatedBy": "email-address-of-the-user",
+        "contract": "contract-this-user-is-on"
+      }
+    ]
+  }
 ]
 ```

--- a/health/db-backups.js
+++ b/health/db-backups.js
@@ -10,64 +10,74 @@ const nHealthCheck = require('n-health/src/checks/check');
 const nHealthStatus = require('n-health/src/checks/status');
 const { Logger } = require('../server/lib/logger');
 
-const {
-	AWS_ACCESS_KEY,
-	AWS_SECRET_ACCESS_KEY,
-	DB
-} = require('config');
+const { AWS_ACCESS_KEY, AWS_SECRET_ACCESS_KEY, DB } = require('config');
 
 const S3 = new AWS.S3({
 	accessKeyId: AWS_ACCESS_KEY,
 	region: 'eu-west-1',
-	secretAccessKey: AWS_SECRET_ACCESS_KEY
+	secretAccessKey: AWS_SECRET_ACCESS_KEY,
 });
 
 S3.listObjectsV2Async = util.promisify(S3.listObjectsV2);
 
-const MODULE_ID = path.relative(process.cwd(), module.id) || require(path.resolve('./package.json')).name;
-const log = new Logger({source: MODULE_ID});
+const MODULE_ID =
+	path.relative(process.cwd(), module.id) ||
+	require(path.resolve('./package.json')).name;
+const log = new Logger({ source: MODULE_ID });
 
-module.exports = exports = new (class S3PostgreSQLBackupCheck extends nHealthCheck {
-	constructor(...args) {
-		super(...args);
+module.exports = exports =
+	new (class S3PostgreSQLBackupCheck extends nHealthCheck {
+		constructor(...args) {
+			super(...args);
 
-		this.interval = 1000 * 60 * 30;
-	}
-
-	async tick() {
-		const START = Date.now();
-
-		this.status = nHealthStatus.PENDING;
-
-		this.checkOutput = 'None';
-
-		const timestamp = (moment().isSameOrAfter(moment().startOf('hour').add(10, 'minutes')) ? moment() : moment().subtract(1, 'hour')).format(DB.BACKUP.date_format);
-
-		try {
-			let res = await S3.listObjectsV2Async({
-				Bucket: DB.BACKUP.bucket.id,
-				MaxKeys: 5,
-				Prefix: `${DB.BACKUP.bucket.directory}/${DB.BACKUP.schema}.${timestamp}`
-			});
-
-			const ok = !!res.Contents.length;
-
-			this.status = ok === true ? nHealthStatus.PASSED : nHealthStatus.FAILED;
-
-			log.info(`${MODULE_ID} in ${Date.now() - START}ms => ${this.checkOutput}`);
-		}
-		catch (e) {
-			this.status = nHealthStatus.ERRORED;
+			this.interval = 1000 * 60 * 30;
 		}
 
-		return this.checkOutput;
-	}
-})({
-	id: 'next-syndication-api-hourly-db-backup',
-	businessImpact: 'The Syndication hourly database backups have not run for the last hour, this could result in loss of data if we need to restore the database after a fatal crash.',
-	name: 'Syndication hourly database backups',
-/*eslint-disable*/
-	panicGuide: `If you want to manually take a backup of the schema and data, you can do so by running:
+		async tick() {
+			const START = Date.now();
+
+			this.status = nHealthStatus.PENDING;
+
+			this.checkOutput = 'None';
+
+			const timestamp = (
+				moment().isSameOrAfter(
+					moment().startOf('hour').add(10, 'minutes')
+				)
+					? moment()
+					: moment().subtract(1, 'hour')
+			).format(DB.BACKUP.date_format);
+
+			try {
+				let res = await S3.listObjectsV2Async({
+					Bucket: DB.BACKUP.bucket.id,
+					MaxKeys: 5,
+					Prefix: `${DB.BACKUP.bucket.directory}/${DB.BACKUP.schema}.${timestamp}`,
+				});
+
+				const ok = !!res.Contents.length;
+
+				this.status =
+					ok === true ? nHealthStatus.PASSED : nHealthStatus.FAILED;
+
+				log.info(
+					`${MODULE_ID} in ${Date.now() - START}ms => ${
+						this.checkOutput
+					}`
+				);
+			} catch (e) {
+				this.status = nHealthStatus.ERRORED;
+			}
+
+			return this.checkOutput;
+		}
+	})({
+		id: 'next-syndication-api-hourly-db-backup',
+		businessImpact:
+			'The Syndication hourly database backups have not run for the last hour, this could result in loss of data if we need to restore the database after a fatal crash.',
+		name: 'Syndication hourly database backups',
+		/*eslint-disable*/
+		panicGuide: `If you want to manually take a backup of the schema and data, you can do so by running:
 
 \`\`\`
 	# DUMP THE SCHEMA
@@ -84,11 +94,12 @@ module.exports = exports = new (class S3PostgreSQLBackupCheck extends nHealthChe
 			--file data.syndication.YYYY-MM-DDTHH.00.sql
 \`\`\`
 
-Substituting the above \`\${PRODUCTION_DATABASE_ *}\` placeholders with the correct values from vault and the \`YYYY-MM-DDTHH\` for the current date rounded to the hour.`,
-/*eslint-enable*/
-	severity: 1,
-	technicalSummary: 'Checks the database backup cron is running and that a zip file — containing the schema dump file and data dump file — for the previous hour has been uploaded to S3.'
-});
+Substituting the above \`\${PRODUCTION_DATABASE_ *}\` placeholders with the correct values from Doppler and the \`YYYY-MM-DDTHH\` for the current date rounded to the hour.`,
+		/*eslint-enable*/
+		severity: 1,
+		technicalSummary:
+			'Checks the database backup cron is running and that a zip file — containing the schema dump file and data dump file — for the previous hour has been uploaded to S3.',
+	});
 
 if (process.env.NODE_ENV !== 'test') {
 	exports.start();

--- a/health/db-sync-state.js
+++ b/health/db-sync-state.js
@@ -54,7 +54,7 @@ module.exports = exports = new (class DBSyncStateCheck extends nHealthCheck {
 			--command 'select syndication.reload_all();'
 \`\`\`
 
-Substituting the above \`\${PRODUCTION_DATABASE_*}\` placeholders with the correct values from vault.`,
+Substituting the above \`\${PRODUCTION_DATABASE_*}\` placeholders with the correct values from Doppler.`,
 /*eslint-enable*/
 	severity: 3,
 	technicalSummary: 'Checks the Syndication database\'s computed tables are correctly representing the base tables\' data.'

--- a/runbook.md
+++ b/runbook.md
@@ -2,6 +2,7 @@
     Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
     Any future edits should abide by this format.
 -->
+
 # Syndication Api
 
 API for FT syndication features
@@ -71,11 +72,13 @@ To debug issues where only one person or one contract can't see the icons, pleas
 
 If _nobody_ can see their icons, then this is a more serious problem and should be pushed to [Second Line](#people-cant-see-their-syndication-icons-second-line) .
 
-#### __Salesforce usage__
+#### **Salesforce usage**
+
 The app connects to Salesforce to get contract details for the user, and updates the Syndication database when it receives them
-* User: `next-syndication`
-* URLs: Logs in and uses an SDK, retrieves details from `/SCRMContract/[someContractID]`
-* Splunk: [index="heroku" source=\*syndication-api\* salesforce error](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D*syndication-api*%20salesforce%20error&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1h&latest=now&sid=1661952146.1430281), `NullApexResponse` is in the error message specifically for the call to Salesforce
+
+- User: `next-syndication`
+- URLs: Logs in and uses an SDK, retrieves details from `/SCRMContract/[someContractID]`
+- Splunk: [index="heroku" source=\*syndication-api\* salesforce error](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D*syndication-api*%20salesforce%20error&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1h&latest=now&sid=1661952146.1430281), `NullApexResponse` is in the error message specifically for the call to Salesforce
 
 ## Second Line Troubleshooting
 
@@ -83,13 +86,14 @@ _NB: There is a common misconception that you need all parts of Syndication to b
 
 ### Check the details of a specific contract
 
-*   **Contract check:** You can see the details of a specific contract by calling `GET https://www.ft.com/syndication/contracts/:contract_id` with a valid api key sent in `x-api-key` header. This will pull details from Salesforce and run them through the API. 
-    * You can find the API key in Vault : `next` team, `next-syndication-api` project, `production` folder, the key is called `SYNDICATION_API_KEY`.
-    * The `:contract_id` should have the `FTS-xxxxxxxx` format, unless it is the FT Staff licence which has a `CA-xxxxxxxx` format and uses a stub rather than Salesforce
-*   **Article republishing permissions check:** `POST` call to `https://www.ft.com/syndication/contracts/:contract_id/resolve` with a valid api key (as above) and a json body which is an array of content ids will return the syndication permissions for each article you listed
-*   **Tip:** You can reuse the [Postman collection](https://github.com/Financial-Times/next-syndication-api/blob/main/doc/syndication-api-postman.json) ([instructions](https://github.com/Financial-Times/next-syndication-api#api-endpoint-postman-collection)) for these API endpoints, you will need to adapt the `local.ft.com url:5050` to `www.ft.com`
+- **Contract check:** You can see the details of a specific contract by calling `GET https://www.ft.com/syndication/contracts/:contract_id` with a valid api key sent in `x-api-key` header. This will pull details from Salesforce and run them through the API.
+  - You can find the API key in Doppler : `next` team, `next-syndication-api` project, `production` folder, the key is called `SYNDICATION_API_KEY`.
+  - The `:contract_id` should have the `FTS-xxxxxxxx` format, unless it is the FT Staff licence which has a `CA-xxxxxxxx` format and uses a stub rather than Salesforce
+- **Article republishing permissions check:** `POST` call to `https://www.ft.com/syndication/contracts/:contract_id/resolve` with a valid api key (as above) and a json body which is an array of content ids will return the syndication permissions for each article you listed
+- **Tip:** You can reuse the [Postman collection](https://github.com/Financial-Times/next-syndication-api/blob/main/doc/syndication-api-postman.json) ([instructions](https://github.com/Financial-Times/next-syndication-api#api-endpoint-postman-collection)) for these API endpoints, you will need to adapt the `local.ft.com url:5050` to `www.ft.com`
 
 ### Check the user status page works
+
 If the problem is happening for everyone, check the `/syndication/user-status` endpoint, otherwise see if you can get the person who is having the issue (or customer support masquerading as that user) to hit the URL while you're tailing the logs and look for any lines that `error: ` this should highlight JavaScript errors.
 
 ### People can't see their syndication icons (second line)
@@ -104,18 +108,19 @@ If they are attached to a syndication license they will have S1 in the list of p
 
 If this is a problem for all Syndication users it could be:
 
-*   Is the `syndication` flag on in our feature flags?
-*   A problem with the front end applications ([next-front-page](https://github.com/Financial-Times/next-front-page), [next-article](https://github.com/Financial-Times/next-article), [next-myft-page](https://github.com/Financial-Times/next-myft-page), [next-stream-page](https://github.com/Financial-Times/next-stream-page), [next-video-page](https://github.com/Financial-Times/next-video-page))
-*   A problem with o-teaser (which is the Origami component that displays syndication icons)
-*   A problem with x-teaser (<https://github.com/Financial-Times/x-dash>)
-*   A problem with [n-syndication](https://github.com/Financial-Times/n-syndication) which contains the logic for the icons
-*   A problem with [next-syndication-api](https://github.com/Financial-Times/next-syndication-api)
-*   A problem with Salesforce (all contracts live in Salesforce)
-*   A problem with [next-syn-list](https://github.com/Financial-Times/next-syn-list)
+- Is the `syndication` flag on in our feature flags?
+- A problem with the front end applications ([next-front-page](https://github.com/Financial-Times/next-front-page), [next-article](https://github.com/Financial-Times/next-article), [next-myft-page](https://github.com/Financial-Times/next-myft-page), [next-stream-page](https://github.com/Financial-Times/next-stream-page), [next-video-page](https://github.com/Financial-Times/next-video-page))
+- A problem with o-teaser (which is the Origami component that displays syndication icons)
+- A problem with x-teaser (<https://github.com/Financial-Times/x-dash>)
+- A problem with [n-syndication](https://github.com/Financial-Times/n-syndication) which contains the logic for the icons
+- A problem with [next-syndication-api](https://github.com/Financial-Times/next-syndication-api)
+- A problem with Salesforce (all contracts live in Salesforce)
+- A problem with [next-syn-list](https://github.com/Financial-Times/next-syn-list)
 
 We can check the details of a specific contract and the user status page to begin to debug the issue. It is useful to tail the heroku logs for next-syndication-api while doing this so you can also see database activity with `heroku logs --app ft-next-syndication-api --tail --num 0 `
 
 #### Conflict of uuids and email addresses
+
 This could be caused too by the user already existing in the database with their old ID and the same email address. The database
 uses the user ID as the primary key and the email address as a unique index. Therefore, when you try to add a new user
 id with an email address that already exists, it will fail. The system isn’t designed to handle user IDs changing.This
@@ -132,7 +137,7 @@ references to the old ID had disappeared.
     UPDATE syndication.save_history SET user_id='newId' WHERE user_id='oldId';
     UPDATE syndication.saved_items SET user_id='newId' WHERE user_id='oldId';
     UPDATE syndication.migrated_users SET user_id='newId' WHERE user_id='oldId';
- COMMIT;  
+ COMMIT;
 ```
 
 ### Contract details not refreshing
@@ -143,13 +148,13 @@ The API won't go query Salesforce unless the `last_updated` date is greater than
 
 ```sql
 
-    UPDATE syndication.contracts 
-       SET (last_updated) = (now() - '25 hours'::interval) 
+    UPDATE syndication.contracts
+       SET (last_updated) = (now() - '25 hours'::interval)
      WHERE contract_id = 'CONTRACT_NUMBER_HAVING_ISSUES';
-``` 
-
+```
 
 ### Masquerading
+
 Aside from saving and downloading content, you can masquerade as a different contract by passing `contract_id=${VALID_CONTRACT_NUMBER}` in the query string of any public endpoint defined that uses contract information.
 
 See [server/middleware/masquerade.js](https://github.com/Financial-Times/next-syndication-api/blob/main/server/middleware/masquerade.js#L6) for implementation. You must have at least a `superuser` role in the syndication user table for this to work.
@@ -167,6 +172,7 @@ Tail the logs and try saving/downloading an item.
 Downloads (served on host dl.syndication.ft.com) are run from the `ft-next-syndication-dl` app so that downloads don't run through router, preflight, etc. Check the `ft-next-syndication-dl` heroku app, make sure it's running, tail its logs and try downloading.
 
 ### Spanish Translations not available
+
 Two places to check: the S3 bucket where translations are placed in XML format, and the content_es table in the syndication database where the article is saved as JSON.
 
 Spanish Translations of articles are provided by a 3rd Party, Vanguard Publications. Our contact Merle Thorpe puts XML files into an S3 bucket (ft-article-translations-en-to-es-from-vanguard-publications), next-syndication-lambdas then listens for files being put in, transforms the files and inserts the translation into the database in a JSON format.
@@ -199,7 +205,6 @@ The last line of your out put should look something like this:
 
 If the last line of your output looks more like this:
 
-
 ```shell
 
     connect: Operation timed out
@@ -213,13 +218,13 @@ Try turning wifi off on your phone to tether your computer to your phone's 4G co
 
 ### Dealing with `no pg_hba.conf entry` - `Syndication database data integrity` errors
 
-Turns out that our Database Integrity healthcheck (db-sync-state) runs against review branches, as well as production. The `DATABASE_URL` secret is not stored in vault; it automatically added by the Postgres add-on. However, this secret is only added to the `prod` app's secrets. If you encounter this error, this is most likely the database secrets were updated. To fix this, you need to get the `DATABASE_URL` secret from the `prod` app, and add it to the review apps' secrets. To do this, go to Heroku's next-syndication-api main pipeline page, click "Configure" in the `Review Apps` column, then select `More settings`. In the `Settings` page, scroll down to `Reveal Config Vars`, reveal the vars and add the `DATABASE_URL` secret
+Turns out that our Database Integrity healthcheck (db-sync-state) runs against review branches, as well as production. The `DATABASE_URL` secret is not stored in Doppler; it automatically added by the Postgres add-on. However, this secret is only added to the `prod` app's secrets. If you encounter this error, this is most likely the database secrets were updated. To fix this, you need to get the `DATABASE_URL` secret from the `prod` app, and add it to the review apps' secrets. To do this, go to Heroku's next-syndication-api main pipeline page, click "Configure" in the `Review Apps` column, then select `More settings`. In the `Settings` page, scroll down to `Reveal Config Vars`, reveal the vars and add the `DATABASE_URL` secret
 
 ### General tips for troubleshooting Customer Products Systems
 
-*   [Out of hours runbook for FT.com (wiki)](https://customer-products.in.ft.com/wiki/Out-of-hours-troubleshooting-guide)
-*   [General tips for debugging FT.com (wiki)](https://customer-products.in.ft.com/wiki/Debugging-Tips).
-*   [General information about monitoring and troubleshooting FT.com systems (wiki)](https://customer-products.in.ft.com/wiki/Monitoring-and-Troubleshooting-systems)
+- [Out of hours runbook for FT.com (wiki)](https://customer-products.in.ft.com/wiki/Out-of-hours-troubleshooting-guide)
+- [General tips for debugging FT.com (wiki)](https://customer-products.in.ft.com/wiki/Debugging-Tips).
+- [General information about monitoring and troubleshooting FT.com systems (wiki)](https://customer-products.in.ft.com/wiki/Monitoring-and-Troubleshooting-systems)
 
 ## Monitoring
 
@@ -231,19 +236,19 @@ Turns out that our Database Integrity healthcheck (db-sync-state) runs against r
 
 ### Pingdom
 
-* [next-syndication-api--eu-gtg](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=4897636)
-* [User Rights US Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834166)
-* [User Rights EU Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834226)
-* [Licence Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834275)
-* [User Profile Service US reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834360)
-* [User Profile Service EU reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834372)
-* [Auth Service US reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834376)
-* [Auth Service EU reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834387)
+- [next-syndication-api--eu-gtg](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=4897636)
+- [User Rights US Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834166)
+- [User Rights EU Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834226)
+- [Licence Service reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834275)
+- [User Profile Service US reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834360)
+- [User Profile Service EU reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834372)
+- [Auth Service US reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834376)
+- [Auth Service EU reachable](https://my.pingdom.com/reports/responsetime#daterange=7days&tab=uptime_tab&check=7834387)
 
 ### Splunk searches
 
-*   [index="heroku" source="next-syndication-api" sourcetype="heroku:app"](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22next-syndication-api%22%20sourcetype%3D%22heroku%3Aapp%22&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-1h&latest=now&workload_pool=standard_perf&sid=1667810937.23521460)
-* Salesforce failures can be found as [index="heroku" source="next-syndication-api" sourcetype="heroku:app" salesforce error](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22next-syndication-api%22%20sourcetype%3D%22heroku%3Aapp%22%20salesforce%20error&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1h&latest=now&sid=1667810888.23521046), `NullApexResponse` is in the error message specifically for the call to Salesforce
+- [index="heroku" source="next-syndication-api" sourcetype="heroku:app"](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22next-syndication-api%22%20sourcetype%3D%22heroku%3Aapp%22&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-1h&latest=now&workload_pool=standard_perf&sid=1667810937.23521460)
+- Salesforce failures can be found as [index="heroku" source="next-syndication-api" sourcetype="heroku:app" salesforce error](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22next-syndication-api%22%20sourcetype%3D%22heroku%3Aapp%22%20salesforce%20error&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1h&latest=now&sid=1667810888.23521046), `NullApexResponse` is in the error message specifically for the call to Salesforce
 
 ## Failover Architecture Type
 

--- a/toolkit/start/index.js
+++ b/toolkit/start/index.js
@@ -1,19 +1,21 @@
 const { Task } = require('@dotcom-tool-kit/types');
 const { spawn } = require('child_process');
 const { hookFork, waitOnExit } = require('@dotcom-tool-kit/logger');
-const Vault = require('@dotcom-tool-kit/vault');
-
+const Doppler = require('@dotcom-tool-kit/doppler');
 
 class SyndicationAPITask extends Task {
 	async run() {
-		const vault = new Vault.VaultEnvVars(this.logger, {
-			environment: 'development'
-		});
-		const vaultEnv = await vault.get();
+		let dopplerEnv;
+
+		if (!process.env.CI) {
+			const doppler = new Doppler.DopplerEnvVars(this.logger, 'dev');
+			dopplerEnv = await doppler.get();
+		}
+
 		this.logger.info('running next-syndication-api');
 		const args = ['start','procfile.json'];
 
-		const env = Object.assign({}, process.env, vaultEnv);
+		const env = Object.assign({}, process.env, dopplerEnv);
 
 		const options = {
 			env,


### PR DESCRIPTION
### Description
- Updates all readme/doc mentions of vault to doppler
- Sets up doppler task in toolkit so it uses doppler for local development
- Uses doppler instead of vault for the `SyndicationAPITask`


### Ticket
[ACC-2770](https://financialtimes.atlassian.net/browse/ACC-2770)

### What is the new version number in package.json?
<!-- If you have made any changes other than documentation, you need to follow a special deploy process, as described here https://github.com/Financial-Times/next-syndication-dl#deploying-the-download-server -->

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->


[ACC-2770]: https://financialtimes.atlassian.net/browse/ACC-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ