### PR TITLE
Add logging when appending captions

### DIFF
--- a/server/lib/download/video.js
+++ b/server/lib/download/video.js
@@ -72,7 +72,14 @@ module.exports = exports = class VideoDownload extends ArticleDownload {
 
 				this.captionFiles = captionFiles;
 
-				captionFiles.forEach(({ file, name }) => this.append(file, { name }));
+				captionFiles.forEach(({ file, name }) => {
+					log.info('appendCaptions', {
+						name,
+						file
+					});
+
+					return this.append(file, { name })
+				});
 
 			}
 			catch (error) {


### PR DESCRIPTION
The caption files are empty so we want to see what exists at this point when running in production as in local the contents exists

