### PR TITLE
ACC-2799: Update n-express to use latest metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@dotcom-reliability-kit/crash-handler": "^2.1.1",
         "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
         "@financial-times/n-es-client": "4.1.0",
-        "@financial-times/n-express": "^27.5.0",
+        "@financial-times/n-express": "^28.3.0",
         "@financial-times/n-mask-logger": "7.2.0",
         "ajv": "^6.0.0",
         "archiver": "^6.0.0",
@@ -565,7 +565,6 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.10.tgz",
       "integrity": "sha512-em76yWZqoA6lXMLYci6HP531KkAN0W2jjlUWp6hP3TnN1FBSFMIJmiJGHDQ1dFo7TtzcjdBLN0YU7ELHi8qmAw==",
-      "dev": true,
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.2.0",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
@@ -584,7 +583,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.2.0.tgz",
       "integrity": "sha512-HG+BLc/YrZ/bitev5CDQiibbGvZEyyDy/U7GWvkAMu5HQhJVMB310MhwO0i3jYfYJGfXuaYZ8eypgbG9TzBdKA==",
-      "dev": true,
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
@@ -594,7 +592,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
-      "dev": true,
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
@@ -1073,22 +1070,20 @@
       }
     },
     "node_modules/@financial-times/n-express": {
-      "version": "27.5.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
-      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-28.3.0.tgz",
+      "integrity": "sha512-AxyuvW3VF+hUr1Rimn8B9Sa2YX+Vnh11p6zlOap2vDndWpQXDWG6IDUiNifxB8jayPttRGX8GECKpKwqk7tjSQ==",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^2.0.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "@dotcom-reliability-kit/serialize-request": "^2.0.0",
-        "@financial-times/n-flags-client": "^13.0.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.3.0",
+        "@financial-times/n-flags-client": "^14.0.1",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^10.0.0",
-        "next-metrics": "^9.2.0",
+        "n-health": "^11.0.0",
+        "next-metrics": "^10.0.10",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -1096,15 +1091,6 @@
       },
       "engines": {
         "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/@dotcom-reliability-kit/serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
-      "engines": {
-        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
       }
     },
@@ -1118,11 +1104,11 @@
       }
     },
     "node_modules/@financial-times/n-express/node_modules/n-health": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
-      "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-11.0.0.tgz",
+      "integrity": "sha512-m63Ti63Vhe13sMsOGJpZHIho7WKKPVRvkyDjUeHelXV7pMhY/KVHBnXBegGWZUkQ7teqdxsfhcC+vFXU7J1LnA==",
       "dependencies": {
-        "@financial-times/n-logger": "^10.2.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",
@@ -1150,11 +1136,11 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
-      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+      "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
       "dependencies": {
-        "@financial-times/n-logger": "^10.2.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       },
@@ -1225,21 +1211,6 @@
       },
       "engines": {
         "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-raven": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
-      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^1.3.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -1882,7 +1853,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2498,7 +2468,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3239,14 +3208,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -3625,7 +3586,6 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
       "peer": true
     },
     "node_modules/colors": {
@@ -4058,14 +4018,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -4158,7 +4110,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": "*"
@@ -4598,7 +4549,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5320,7 +5270,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5706,7 +5655,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
       "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
-      "dev": true,
       "peer": true
     },
     "node_modules/fast-deep-equal": {
@@ -5739,7 +5687,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
       "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5747,8 +5694,7 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -6829,7 +6775,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
       "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "glob": "^8.0.0",
@@ -6840,7 +6785,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6850,7 +6794,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6870,7 +6813,6 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6883,7 +6825,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7519,7 +7460,8 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -8152,7 +8094,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -8508,8 +8449,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -8806,16 +8746,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -9688,11 +9618,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next-metrics": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
-      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.10.tgz",
+      "integrity": "sha512-cN2THWqnr0oLavqcqjhnxGTEUcJyASbr95EaRSJZM8PnNKAonaiacgyzStWywNo8IN+/2xBii4FuPpIj2RzPWw==",
       "dependencies": {
-        "@financial-times/n-logger": "^10.2.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
@@ -14501,7 +14431,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15085,7 +15014,6 @@
       "version": "8.16.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.1.tgz",
       "integrity": "sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==",
-      "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -15107,7 +15035,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
       "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
-      "dev": true,
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -15117,7 +15044,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15141,7 +15067,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -15150,7 +15075,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15170,7 +15094,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
       "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -15186,7 +15109,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -15195,7 +15117,6 @@
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.3.tgz",
       "integrity": "sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "colorette": "^2.0.7",
@@ -15221,7 +15142,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15246,7 +15166,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
@@ -15256,7 +15175,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15277,7 +15195,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15287,7 +15204,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
       "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -15304,7 +15220,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -15313,8 +15228,7 @@
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-      "dev": true
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
@@ -15747,7 +15661,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -15760,8 +15673,7 @@
     "node_modules/process-warning": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.0.tgz",
-      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g==",
-      "dev": true
+      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -15890,7 +15802,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -16040,8 +15951,7 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -16049,42 +15959,6 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "deprecated": "Please upgrade to @sentry/node. See the migration guide https://bit.ly/3ybOlo7",
-      "dependencies": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "bin": {
-        "raven": "bin/raven"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/raven/node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raven/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/raw-body": {
@@ -16235,7 +16109,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "dev": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -16737,7 +16610,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -16756,7 +16628,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/semver": {
@@ -17357,7 +17228,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
       "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
-      "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -17772,7 +17642,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -17981,7 +17850,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
       "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
-      "dev": true,
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -17996,6 +17864,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20370,7 +20239,6 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.10.tgz",
       "integrity": "sha512-em76yWZqoA6lXMLYci6HP531KkAN0W2jjlUWp6hP3TnN1FBSFMIJmiJGHDQ1dFo7TtzcjdBLN0YU7ELHi8qmAw==",
-      "dev": true,
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.2.0",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
@@ -20381,14 +20249,12 @@
         "@dotcom-reliability-kit/app-info": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.2.0.tgz",
-          "integrity": "sha512-HG+BLc/YrZ/bitev5CDQiibbGvZEyyDy/U7GWvkAMu5HQhJVMB310MhwO0i3jYfYJGfXuaYZ8eypgbG9TzBdKA==",
-          "dev": true
+          "integrity": "sha512-HG+BLc/YrZ/bitev5CDQiibbGvZEyyDy/U7GWvkAMu5HQhJVMB310MhwO0i3jYfYJGfXuaYZ8eypgbG9TzBdKA=="
         },
         "@dotcom-reliability-kit/serialize-error": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
-          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
-          "dev": true
+          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
         }
       }
     },
@@ -20722,41 +20588,34 @@
       }
     },
     "@financial-times/n-express": {
-      "version": "27.5.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
-      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-28.3.0.tgz",
+      "integrity": "sha512-AxyuvW3VF+hUr1Rimn8B9Sa2YX+Vnh11p6zlOap2vDndWpQXDWG6IDUiNifxB8jayPttRGX8GECKpKwqk7tjSQ==",
       "requires": {
         "@dotcom-reliability-kit/errors": "^2.0.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "@dotcom-reliability-kit/serialize-request": "^2.0.0",
-        "@financial-times/n-flags-client": "^13.0.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.3.0",
+        "@financial-times/n-flags-client": "^14.0.1",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^10.0.0",
-        "next-metrics": "^9.2.0",
+        "n-health": "^11.0.0",
+        "next-metrics": "^10.0.10",
         "semver": "^7.3.7"
       },
       "dependencies": {
-        "@dotcom-reliability-kit/serialize-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
-          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
-        },
         "@dotcom-reliability-kit/serialize-request": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
           "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
         },
         "n-health": {
-          "version": "10.1.1",
-          "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
-          "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/n-health/-/n-health-11.0.0.tgz",
+          "integrity": "sha512-m63Ti63Vhe13sMsOGJpZHIho7WKKPVRvkyDjUeHelXV7pMhY/KVHBnXBegGWZUkQ7teqdxsfhcC+vFXU7J1LnA==",
           "requires": {
-            "@financial-times/n-logger": "^10.2.0",
+            "@dotcom-reliability-kit/logger": "^2.2.6",
             "aws-sdk": "^2.6.10",
             "fetchres": "^1.5.1",
             "moment": "^2.29.4",
@@ -20778,11 +20637,11 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
-      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+      "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
       "requires": {
-        "@financial-times/n-logger": "^10.2.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       },
@@ -20834,16 +20693,6 @@
       "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0"
-      }
-    },
-    "@financial-times/n-raven": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
-      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
-      "requires": {
-        "@dotcom-reliability-kit/log-error": "^1.3.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
       }
     },
     "@financial-times/n-test": {
@@ -21385,7 +21234,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -21862,8 +21710,7 @@
     "atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -22436,11 +22283,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
-    },
     "charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -22747,7 +22589,6 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
       "peer": true
     },
     "colors": {
@@ -23086,11 +22927,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
-    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -23166,7 +23002,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-      "dev": true,
       "peer": true
     },
     "debounce": {
@@ -23520,7 +23355,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -24092,8 +23926,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter2": {
       "version": "1.0.5",
@@ -24425,7 +24258,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
       "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
-      "dev": true,
       "peer": true
     },
     "fast-deep-equal": {
@@ -24457,14 +24289,12 @@
     "fast-redact": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
-      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
-      "dev": true
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.15.0",
@@ -25274,7 +25104,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
       "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "glob": "^8.0.0",
@@ -25285,7 +25114,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -25295,7 +25123,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
           "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-          "dev": true,
           "peer": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -25309,7 +25136,6 @@
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
           "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-          "dev": true,
           "peer": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -25319,7 +25145,6 @@
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
           "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -25808,7 +25633,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.7",
@@ -26271,7 +26097,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
       "peer": true
     },
     "jpeg-js": {
@@ -26554,8 +26379,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -26807,16 +26631,6 @@
             "path-is-absolute": "^1.0.0"
           }
         }
-      }
-    },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {
@@ -27523,11 +27337,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next-metrics": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
-      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.10.tgz",
+      "integrity": "sha512-cN2THWqnr0oLavqcqjhnxGTEUcJyASbr95EaRSJZM8PnNKAonaiacgyzStWywNo8IN+/2xBii4FuPpIj2RzPWw==",
       "requires": {
-        "@financial-times/n-logger": "^10.2.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       }
@@ -31101,8 +30915,7 @@
     "on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "dev": true
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
     },
     "on-finished": {
       "version": "2.4.1",
@@ -31553,7 +31366,6 @@
       "version": "8.16.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.1.tgz",
       "integrity": "sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==",
-      "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -31572,7 +31384,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
       "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
-      "dev": true,
       "requires": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -31582,7 +31393,6 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -31591,20 +31401,17 @@
         "events": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
         "ieee754": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-          "dev": true
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "readable-stream": {
           "version": "4.4.2",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
           "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "buffer": "^6.0.3",
@@ -31617,7 +31424,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -31628,7 +31434,6 @@
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.3.tgz",
       "integrity": "sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==",
-      "dev": true,
       "peer": true,
       "requires": {
         "colorette": "^2.0.7",
@@ -31651,7 +31456,6 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
@@ -31662,28 +31466,24 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
           "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true,
           "peer": true
         },
         "ieee754": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-          "dev": true,
           "peer": true
         },
         "minimist": {
           "version": "1.2.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
           "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true,
           "peer": true
         },
         "readable-stream": {
           "version": "4.4.2",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
           "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "abort-controller": "^3.0.0",
@@ -31697,7 +31497,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -31708,8 +31507,7 @@
     "pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-      "dev": true
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "pkg-dir": {
       "version": "5.0.0",
@@ -32051,8 +31849,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -32062,8 +31859,7 @@
     "process-warning": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.0.tgz",
-      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g==",
-      "dev": true
+      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g=="
     },
     "progress": {
       "version": "2.0.3",
@@ -32173,7 +31969,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "peer": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -32280,37 +32075,12 @@
     "quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
     },
     "raw-body": {
       "version": "2.5.1",
@@ -32443,8 +32213,7 @@
     "real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "dev": true
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "rechoir": {
       "version": "0.6.2",
@@ -32817,8 +32586,7 @@
     "safe-stable-stringify": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "dev": true
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -32834,7 +32602,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
       "peer": true
     },
     "semver": {
@@ -33328,7 +33095,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
       "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
-      "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0"
       }
@@ -33667,8 +33433,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "superagent": {
       "version": "6.1.0",
@@ -33841,7 +33606,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
       "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
-      "dev": true,
       "requires": {
         "real-require": "^0.2.0"
       }
@@ -33855,7 +33619,8 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
+      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",
     "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
     "@financial-times/n-es-client": "4.1.0",
-    "@financial-times/n-express": "^27.5.0",
+    "@financial-times/n-express": "^28.3.0",
     "@financial-times/n-mask-logger": "7.2.0",
     "ajv": "^6.0.0",
     "archiver": "^6.0.0",


### PR DESCRIPTION
### Description
The version of next-metrics used by next-syndication-api / next-syndication-dl is not up to date so we are getting alerts when users try and download an article with a renditions video included.

### Ticket
[ACC-2799](https://financialtimes.atlassian.net/browse/ACC-2799)
### What is the new version number in package.json?
2.0.4


[ACC-2799]: https://financialtimes.atlassian.net/browse/ACC-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ