### PR TITLE
Orders status bug Active -> Activated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -38,8 +38,8 @@ module.exports = exports = async (req, res, next) => {
 			if (req.query.save !== '0') {
 				let contract_data = reformatSalesforceContract(JSON.parse(JSON.stringify(contract)));
 				contract_data.last_updated = new Date();
-				if (contract_data.orders) {
-					const activeOrder = contract_data.orders.find(order => order.status === 'Activated');
+				if (contract.orders) {
+					const activeOrder = contract.orders.find(order => order.status === 'Activated');
 					contract_data.current_start_date = new Date(activeOrder.startDate);
 					contract_data.current_end_date = new Date(activeOrder.endDate);
 				}

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -39,9 +39,10 @@ module.exports = exports = async (req, res, next) => {
 				let contract_data = reformatSalesforceContract(JSON.parse(JSON.stringify(contract)));
 				contract_data.last_updated = new Date();
 				if (contract.orders) {
-					const activeOrder = contract.orders.find(order => order.status === 'Activated');
-					contract_data.current_start_date = new Date(activeOrder.startDate);
-					contract_data.current_end_date = new Date(activeOrder.endDate);
+					const now = new Date();
+					const activeOrder = contract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= now && new Date(order?.endDate) >= now);
+					contract_data.current_start_date = new Date(activeOrder?.startDate);
+					contract_data.current_end_date = new Date(activeOrder?.endDate);
 				}
 				contract_data = pgMapColumns(contract_data, contractsColumnMappings);
 

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -39,7 +39,7 @@ module.exports = exports = async (req, res, next) => {
 				let contract_data = reformatSalesforceContract(JSON.parse(JSON.stringify(contract)));
 				contract_data.last_updated = new Date();
 				if (contract_data.orders) {
-					const activeOrder = contract_data.orders.find(order => order.status === 'Active');
+					const activeOrder = contract_data.orders.find(order => order.status === 'Activated');
 					contract_data.current_start_date = new Date(activeOrder.startDate);
 					contract_data.current_end_date = new Date(activeOrder.endDate);
 				}

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -39,8 +39,8 @@ module.exports = exports = async (req, res, next) => {
 				let contract_data = reformatSalesforceContract(JSON.parse(JSON.stringify(contract)));
 				contract_data.last_updated = new Date();
 				if (contract.orders) {
-					const now = new Date();
-					const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= now && new Date(order.endDate) >= now);
+					const currentTimeInMilliseconds = new Date();
+					const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= currentTimeInMilliseconds && new Date(order.endDate) >= currentTimeInMilliseconds);
 					contract_data.current_start_date = new Date(activeOrder.startDate);
 					contract_data.current_end_date = new Date(activeOrder.endDate);
 				}

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -40,9 +40,9 @@ module.exports = exports = async (req, res, next) => {
 				contract_data.last_updated = new Date();
 				if (contract.orders) {
 					const now = new Date();
-					const activeOrder = contract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= now && new Date(order?.endDate) >= now);
-					contract_data.current_start_date = new Date(activeOrder?.startDate);
-					contract_data.current_end_date = new Date(activeOrder?.endDate);
+					const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= now && new Date(order.endDate) >= now);
+					contract_data.current_start_date = new Date(activeOrder.startDate);
+					contract_data.current_end_date = new Date(activeOrder.endDate);
 				}
 				contract_data = pgMapColumns(contract_data, contractsColumnMappings);
 

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -107,7 +107,7 @@ module.exports = exports = async (contractId, locals = {}) => {
 		contract = reformatSalesforceContract(contract);
 		contract.last_updated = new Date();
 		if (contract.orders) {
-			const activeOrder = contract.orders.find(order => order.status === 'Active');
+			const activeOrder = contract.orders.find(order => order.status === 'Activated');
 			contract.current_start_date = new Date(activeOrder.startDate);
 			contract.current_end_date = new Date(activeOrder.endDate);
 		}

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -107,8 +107,8 @@ module.exports = exports = async (contractId, locals = {}) => {
 		contract = reformatSalesforceContract(contract);
 		contract.last_updated = new Date();
 		if (contract.orders) {
-			const now = new Date();
-			const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= now && new Date(order.endDate) >= now);
+			const currentTimeInMilliseconds = new Date();
+			const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= currentTimeInMilliseconds && new Date(order.endDate) >= currentTimeInMilliseconds);
 			contract.current_start_date = new Date(activeOrder.startDate);
 			contract.current_end_date = new Date(activeOrder.endDate);
 		}

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -108,9 +108,9 @@ module.exports = exports = async (contractId, locals = {}) => {
 		contract.last_updated = new Date();
 		if (contract.orders) {
 			const now = new Date();
-			const activeOrder = contract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= now && new Date(order?.endDate) >= now);
-			contract.current_start_date = new Date(activeOrder?.startDate);
-			contract.current_end_date = new Date(activeOrder?.endDate);
+			const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= now && new Date(order.endDate) >= now);
+			contract.current_start_date = new Date(activeOrder.startDate);
+			contract.current_end_date = new Date(activeOrder.endDate);
 		}
 
 		contract = pgMapColumns(contract, contractsColumnMappings);

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -107,9 +107,10 @@ module.exports = exports = async (contractId, locals = {}) => {
 		contract = reformatSalesforceContract(contract);
 		contract.last_updated = new Date();
 		if (contract.orders) {
-			const activeOrder = contract.orders.find(order => order.status === 'Activated');
-			contract.current_start_date = new Date(activeOrder.startDate);
-			contract.current_end_date = new Date(activeOrder.endDate);
+			const now = new Date();
+			const activeOrder = contract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= now && new Date(order?.endDate) >= now);
+			contract.current_start_date = new Date(activeOrder?.startDate);
+			contract.current_end_date = new Date(activeOrder?.endDate);
 		}
 
 		contract = pgMapColumns(contract, contractsColumnMappings);


### PR DESCRIPTION
### Description
While testing some changes I realised that the `current_start_date` and `current_end_date` in a multiyear contract were not being populated in the database. While comparing the code and the salesforce contract I realised that we were looking for orders with `status:Active` while the contract stated `status:Activated`. I asked the Salesforce team and there was a miscommunication, while we were given contracts with order status of `Active` to test with, in production it has always been `Activated`. The salesforce team is currently assessing business impact of this.

An additional check has been implemented to make sure that the current date is in between the activated order's start and end date as per recommendation from the Salesforce team.

### What is the new version number in package.json?
2.0.5

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
https://github.com/Financial-Times/next-syndication-dl/pull/163
