### PR TITLE
bugfix: make variables more explicit and reuse them less

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",


### PR DESCRIPTION
### Description
bug in: server/lib/get-contract-by-id.js line 107
```
contract = reformatSalesforceContract(contract);
```
Since the contract returned by `getSalesforceContractByID(contractId);` assigned to the variable ` contract` was being reassigned by the contract returned from `reformatSalesforceContract(contract);` the `orders` object that came from SalesForce but is not needed in our database was being lost. Therefore when we did:
```
const activeOrder = contract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= currentTimeInMilliseconds && new Date(order.endDate) >= currentTimeInMilliseconds);
```

No activeOrder was being found.

This PR makes variable names more explicit and reuses them less to avoid issues from mutations.


### Ticket
https://financialtimes.atlassian.net/browse/ACC-2934

### What is the new version number in package.json?
2.0.6

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->
