### PR TITLE
Update deprecated Buffer usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",

--- a/test/worker/sync/db-persist/spoor-publish.spec.js
+++ b/test/worker/sync/db-persist/spoor-publish.spec.js
@@ -130,7 +130,7 @@ describe(MODULE_ID, function () {
 		expect(fetchStub).to.be.calledWith('https://spoor-api.ft.com/ingest', {
 			body: JSON.stringify(data),
 			headers: {
-				'content-Length': new Buffer(JSON.stringify(data)).length,
+				'content-Length': Buffer.from(JSON.stringify(data)).length,
 				'cookie': event.tracking.cookie,
 				'spoor-id': event.tracking.spoor_id,
 				'spoor-ticket': event._id,

--- a/worker/sync/db-persist/spoor-publish.js
+++ b/worker/sync/db-persist/spoor-publish.js
@@ -80,7 +80,7 @@ module.exports = exports = async (event) => {
 		const headers = {
 			'accept': 'application/json',
 			'content-type': 'application/json',
-			'content-Length': new Buffer(JSON.stringify(data)).length,
+			'content-Length': Buffer.from(JSON.stringify(data)).length,
 			'cookie': event.tracking.cookie,
 			'spoor-id': event.tracking.spoor_id,
 			'spoor-ticket': event._id,


### PR DESCRIPTION
### Description
This PR updates the usage of `new Buffer` which will output the following warning:

> (node:9017) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

#### References
- [Stack Overflow: DeprecationWarning: Buffer() is deprecated due to security and usability issues when I move my script to another server](https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues#answer-52257416)

```js
new Buffer(number)            // Old
Buffer.alloc(number)          // New

new Buffer(string)            // Old
Buffer.from(string)           // New

new Buffer(string, encoding)  // Old
Buffer.from(string, encoding) // New

new Buffer(...arguments)      // Old
Buffer.from(...arguments)     // New
```

### Ticket
N/A

### What is the new version number in package.json?
2.0.7

### TODO (post-merge)
- [ ] Create and merge next-syndication-dl PR which bumps the next-syndication-api version

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
TODO