### PR TITLE
BugFix: Add optional chaining to activeOrders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 2017,
+		'ecmaVersion': 2020,
 		'sourceType': 'module'
 	},
 	'rules': {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^2.1.1",

--- a/server/controllers/get-contract-by-id.js
+++ b/server/controllers/get-contract-by-id.js
@@ -38,11 +38,11 @@ module.exports = exports = async (req, res, next) => {
 			if (req.query.save !== '0') {
 				reformattedContract = reformatSalesforceContract(JSON.parse(JSON.stringify(sfContract)));
 				reformattedContract.last_updated = new Date();
-				if (sfContract.orders) {
+				if (sfContract?.orders) {
 					const currentTimeInMilliseconds = new Date();
-					const activeOrder = sfContract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= currentTimeInMilliseconds && new Date(order.endDate) >= currentTimeInMilliseconds);
-					reformattedContract.current_start_date = new Date(activeOrder.startDate);
-					reformattedContract.current_end_date = new Date(activeOrder.endDate);
+					const activeOrder = sfContract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= currentTimeInMilliseconds && new Date(order?.endDate) >= currentTimeInMilliseconds);
+					reformattedContract.current_start_date = new Date(activeOrder?.startDate);
+					reformattedContract.current_end_date = new Date(activeOrder?.endDate);
 				}
 				let mappedContract = pgMapColumns(reformattedContract, contractsColumnMappings);
 

--- a/server/lib/get-contract-by-id.js
+++ b/server/lib/get-contract-by-id.js
@@ -107,11 +107,11 @@ module.exports = exports = async (contractId, locals = {}) => {
 	if (sfContract.success === true) {
 		let reformattedContract = reformatSalesforceContract(sfContract);
 		reformattedContract.last_updated = new Date();
-		if (sfContract.orders) {
+		if (sfContract?.orders) {
 			const currentTimeInMilliseconds = new Date();
-			const activeOrder = sfContract.orders.find(order => order.status === 'Activated' && new Date(order.startDate) <= currentTimeInMilliseconds && new Date(order.endDate) >= currentTimeInMilliseconds);
-			reformattedContract.current_start_date = new Date(activeOrder.startDate);
-			reformattedContract.current_end_date = new Date(activeOrder.endDate);
+			const activeOrder = sfContract.orders.find(order => order?.status === 'Activated' && new Date(order?.startDate) <= currentTimeInMilliseconds && new Date(order?.endDate) >= currentTimeInMilliseconds);
+			reformattedContract.current_start_date = new Date(activeOrder?.startDate);
+			reformattedContract.current_end_date = new Date(activeOrder?.endDate);
 		}
 
 		const mappedContract = pgMapColumns(reformattedContract, contractsColumnMappings);


### PR DESCRIPTION
### Description
Getting the activeOrder's start and end date is something that is specific to multiyear contracts. There will sometimes not be an active order so we should expect for these values to be undefined. Added optional chaining to avoid errors.

eslint's ecmaVersion was increased so that the linter supports optional chaining

### Ticket
<!-- Add link to the corresponding ticket -->

### What is the new version number in package.json?
v2.0.8

### Link to the next-syndication-dl PR which bumps the next-syndication-api version
<!-- Add link to the PR -->
