### PR TITLE
ACC-3368 Remove Snyk References

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "proxyquire": "^1.7.4",
         "sinon": "^6.0.0",
         "sinon-chai": "^3.2.0",
-        "snyk": "^1.996.0",
         "unzipper": "^0.10.11"
       },
       "engines": {
@@ -17419,18 +17418,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.1080.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1080.0.tgz",
-      "integrity": "sha512-ELqdJ8hCM/oWyMGbclhRkqezvBtJBBjT99AtpqKgIZu8TNCa8NPYc2TlgqCDaxERr2QYtzeh/qXE56EziDt1LA==",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -33430,12 +33417,6 @@
       "requires": {
         "hoek": "2.x.x"
       }
-    },
-    "snyk": {
-      "version": "1.1080.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1080.0.tgz",
-      "integrity": "sha512-ELqdJ8hCM/oWyMGbclhRkqezvBtJBBjT99AtpqKgIZu8TNCa8NPYc2TlgqCDaxERr2QYtzeh/qXE56EziDt1LA==",
-      "dev": true
     },
     "socks": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "proxyquire": "^1.7.4",
     "sinon": "^6.0.0",
     "sinon-chai": "^3.2.0",
-    "snyk": "^1.996.0",
     "unzipper": "^0.10.11"
   },
   "nyc": {
@@ -110,7 +109,6 @@
   "scripts": {
     "commit": "commit-wizard",
     "heroku-postbuild": "dotcom-tool-kit build:remote release:remote cleanup:remote",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
     "build": "dotcom-tool-kit build:local",
     "test": "export IGNORE_A11Y=true; export NEW_SYNDICATION_USERS=testUserUuid1,testUserUuid2;  export NEW_SYNDICATION_USERS_AWAITING=testUserUuid3,testUserUuid4; export NODE_ENV=test; dotcom-tool-kit test:local",
     "start": "dotcom-tool-kit run:local",


### PR DESCRIPTION
Usage of Snyk at the FT is deprecated.We will not be renewing our licence after 19th December 2024, therefore we are removing all references to it.