### PR TITLE
Revert "update node engine version to 22.x and npm to 10.x"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:22.12-browsers
+      - image: cimg/node:18.17-browsers
 jobs:
   checkout:
     docker:

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -21,7 +21,7 @@ hooks:
 options:
   "@dotcom-tool-kit/mocha": {}
   "@dotcom-tool-kit/eslint": {}
-  "@dotcom-tool-kit/circleci": { nodeVersion: 22.12-browsers }
+  "@dotcom-tool-kit/circleci": { nodeVersion: 18.17-browsers }
   "@dotcom-tool-kit/heroku":
     pipeline: ft-next-syndication-api
     systemCode: next-syndication-api

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-next-syndication-api",
-  "version": "3.0.0",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-next-syndication-api",
-      "version": "3.0.0",
+      "version": "2.0.9",
       "dependencies": {
         "@dotcom-reliability-kit/crash-handler": "^4.1.11",
         "@dotcom-reliability-kit/middleware-log-errors": "^4.2.5",
@@ -67,8 +67,7 @@
         "unzipper": "^0.10.11"
       },
       "engines": {
-        "node": "22.x",
-        "npm": "10.x"
+        "node": "18.x"
       }
     },
     "node_modules/@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-next-syndication-api",
   "description": "Next Syndication API",
-  "version": "3.0.0",
+  "version": "2.0.9",
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^4.1.11",
@@ -104,8 +104,7 @@
     ]
   },
   "engines": {
-    "node": "22.x",
-    "npm": "10.x"
+    "node": "18.x"
   },
   "scripts": {
     "commit": "commit-wizard",
@@ -128,6 +127,6 @@
     }
   },
   "volta": {
-    "node": "22.12.0"
+    "node": "18.17.0"
   }
 }


### PR DESCRIPTION
### Description

Rollback to node 18 because the users cannot see the republish icon.

### Ticket

[LIF-30](https://financialtimes.atlassian.net/browse/LIF-30)




[LIF-30]: https://financialtimes.atlassian.net/browse/LIF-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ