### PR TITLE
Migrate to Reliability Kit logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "3.0.1",
       "dependencies": {
         "@dotcom-reliability-kit/crash-handler": "^5.0.0",
+        "@dotcom-reliability-kit/logger": "^4.1.0",
         "@dotcom-reliability-kit/middleware-log-errors": "^5.0.0",
         "@financial-times/n-es-client": "^6.0.1",
         "@financial-times/n-express": "^31.9.4",
-        "@financial-times/n-mask-logger": "7.2.0",
         "ajv": "^6.0.0",
         "archiver": "^6.0.0",
         "aws-sdk": "^2.85.0",
@@ -1231,24 +1231,6 @@
         "node": "20.x || 22.x"
       }
     },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.0.0.tgz",
-      "integrity": "sha512-avgvRd4cqUmn30dm5t8CqtmrHugEeCTTC6CAVVjcF1elEQeuvHYiKaWbNKftVO54kk5LeZ6enV6HDN71tHBYNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^4.0.0",
-        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
-        "lodash.clonedeep": "^4.5.0",
-        "pino": "^9.6.0"
-      },
-      "engines": {
-        "node": "20.x || 22.x"
-      },
-      "peerDependencies": {
-        "pino-pretty": ">=7.0.0 <11.0.0"
-      }
-    },
     "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/serialize-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
@@ -1267,111 +1249,40 @@
         "node": "20.x || 22.x"
       }
     },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/pino": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
-      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/process-warning": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
-      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "node_modules/@dotcom-reliability-kit/logger": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.10.tgz",
-      "integrity": "sha512-em76yWZqoA6lXMLYci6HP531KkAN0W2jjlUWp6hP3TnN1FBSFMIJmiJGHDQ1dFo7TtzcjdBLN0YU7ELHi8qmAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.1.0.tgz",
+      "integrity": "sha512-on88GAaV/shWS3otQ+M4wn5v/RZvRJxFoDz9IzV7STW5CTnfumH7ftdi5Qo0xVLQpbCTEy1heC1fKz6BwJRX6Q==",
+      "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^2.2.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
-        "pino": "^8.15.1"
+        "pino": "^9.6.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "20.x || 22.x"
       },
       "peerDependencies": {
         "pino-pretty": ">=7.0.0 <11.0.0"
       }
     },
     "node_modules/@dotcom-reliability-kit/logger/node_modules/@dotcom-reliability-kit/app-info": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.2.0.tgz",
-      "integrity": "sha512-HG+BLc/YrZ/bitev5CDQiibbGvZEyyDy/U7GWvkAMu5HQhJVMB310MhwO0i3jYfYJGfXuaYZ8eypgbG9TzBdKA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-4.1.0.tgz",
+      "integrity": "sha512-Ny5oQi+jOWcXNXjRdI37QeNcRZTjuBZGj3RXAT0tXKSUgKlnpPdkwV5L9lSiaK9EmWmuczIiHn11RCZ/M8Eegw==",
+      "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "20.x || 22.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/logger/node_modules/@dotcom-reliability-kit/serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
+      "integrity": "sha512-nMt/bYRzdFEtq9JM5S6nBL3+UaO+XQTf8mYTPa7Tl7x0A+A31XGnpCcIOite4NekbSaWEVagzJBAK5xaJCklYQ==",
+      "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "20.x || 22.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/middleware-log-errors": {
@@ -1898,6 +1809,88 @@
         "npm": "9.x || 10.x"
       }
     },
+    "node_modules/@financial-times/n-es-client/node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.3.0.tgz",
+      "integrity": "sha512-LMyL1tmNOl5aRtBih4EewqXEUK8oOF7j4sa8WCnDUdVlJedUl09iZrBk5th20qvgk2DzO0b5XwKVPLsVWvutCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/@dotcom-reliability-kit/logger": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.4.2.tgz",
+      "integrity": "sha512-Gv5mist7h61Ostagp08KnyyCn25FgzSKRdpIPRTbd412pci8i3rHLwADHUROfDjvNX/bVRBd0sda9RCbkF6aIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.3.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.17.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "pino-pretty": ">=7.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.2.1.tgz",
+      "integrity": "sha512-JP8skyGR3YcCo2tTZogYoLUPWrs5Se+d07MZfBeCXMb2+2BmM79/3V8B6HJ8jPFq6/f6nVVFbQ7VpgHnNk6T2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@financial-times/n-es-client/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/@financial-times/n-express": {
       "version": "31.9.4",
       "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-31.9.4.tgz",
@@ -1937,135 +1930,6 @@
         "pino-pretty": ">=7.0.0 <11.0.0"
       }
     },
-    "node_modules/@financial-times/n-express/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/@financial-times/n-express/node_modules/pino": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-      "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-    },
-    "node_modules/@financial-times/n-express/node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-    },
-    "node_modules/@financial-times/n-express/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/sonic-boom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-      "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/@financial-times/n-express/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "node_modules/@financial-times/n-flags-client": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-15.0.1.tgz",
@@ -2080,6 +1944,45 @@
         "npm": "8.x || 9.x || 10.x"
       }
     },
+    "node_modules/@financial-times/n-flags-client/node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.3.0.tgz",
+      "integrity": "sha512-LMyL1tmNOl5aRtBih4EewqXEUK8oOF7j4sa8WCnDUdVlJedUl09iZrBk5th20qvgk2DzO0b5XwKVPLsVWvutCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/@dotcom-reliability-kit/logger": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.4.2.tgz",
+      "integrity": "sha512-Gv5mist7h61Ostagp08KnyyCn25FgzSKRdpIPRTbd412pci8i3rHLwADHUROfDjvNX/bVRBd0sda9RCbkF6aIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.3.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.17.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "pino-pretty": ">=7.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.2.1.tgz",
+      "integrity": "sha512-JP8skyGR3YcCo2tTZogYoLUPWrs5Se+d07MZfBeCXMb2+2BmM79/3V8B6HJ8jPFq6/f6nVVFbQ7VpgHnNk6T2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
     "node_modules/@financial-times/n-flags-client/node_modules/n-eager-fetch": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.2.0.tgz",
@@ -2091,6 +1994,49 @@
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x || 10.x"
+      }
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@financial-times/n-flags-client/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@financial-times/n-logger": {
@@ -2130,21 +2076,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/@financial-times/n-mask-logger": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
-      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
-      "deprecated": "n-mask-logger is no longer supported. It will get security patches up until 2023-10-20. You should migrate to Reliability Kit Logger before this date https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@financial-times/n-logger": "^10.2.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-test": {
@@ -11857,135 +11788,6 @@
         "pino-pretty": ">=7.0.0 <11.0.0"
       }
     },
-    "node_modules/n-health/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/n-health/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/n-health/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/n-health/node_modules/pino": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-      "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/n-health/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/n-health/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-    },
-    "node_modules/n-health/node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-    },
-    "node_modules/n-health/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/n-health/node_modules/sonic-boom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-      "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/n-health/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/n-health/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "node_modules/nan": {
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
@@ -12111,135 +11913,6 @@
       },
       "peerDependencies": {
         "pino-pretty": ">=7.0.0 <11.0.0"
-      }
-    },
-    "node_modules/next-metrics/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/next-metrics/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/next-metrics/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/next-metrics/node_modules/pino": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-      "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/next-metrics/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/next-metrics/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-    },
-    "node_modules/next-metrics/node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-    },
-    "node_modules/next-metrics/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/next-metrics/node_modules/sonic-boom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-      "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/next-metrics/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/next-metrics/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/next-tick": {
@@ -17596,30 +17269,32 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.1.tgz",
-      "integrity": "sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
+      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.1.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.0.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
-      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -17811,9 +17486,28 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/pino/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
@@ -18501,9 +18195,20 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/process-warning": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.0.tgz",
-      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -20633,9 +20338,10 @@
       "dev": true
     },
     "node_modules/thread-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
-      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -23571,17 +23277,6 @@
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-4.0.0.tgz",
           "integrity": "sha512-bGqI4Dmez4c5yIqoVwLVub7Rn6bP9CC0JWUpZQhtrnmR5czLCxc8LqFJwS1YYPeUqWyuMB2SSacxhgnBlgBikQ=="
         },
-        "@dotcom-reliability-kit/logger": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.0.0.tgz",
-          "integrity": "sha512-avgvRd4cqUmn30dm5t8CqtmrHugEeCTTC6CAVVjcF1elEQeuvHYiKaWbNKftVO54kk5LeZ6enV6HDN71tHBYNw==",
-          "requires": {
-            "@dotcom-reliability-kit/app-info": "^4.0.0",
-            "@dotcom-reliability-kit/serialize-error": "^4.0.0",
-            "lodash.clonedeep": "^4.5.0",
-            "pino": "^9.6.0"
-          }
-        },
         "@dotcom-reliability-kit/serialize-error": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
@@ -23591,81 +23286,29 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-4.0.0.tgz",
           "integrity": "sha512-2EfidEQxTtTl+0wxgpmI3CxjzXpKSTgJ11rY8J+ugV3sd+f2h0e0U06QiOfackgQkUcYImh1jFQVq51NoVI+uw=="
-        },
-        "pino": {
-          "version": "9.6.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
-          "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "fast-redact": "^3.1.1",
-            "on-exit-leak-free": "^2.1.0",
-            "pino-abstract-transport": "^2.0.0",
-            "pino-std-serializers": "^7.0.0",
-            "process-warning": "^4.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "real-require": "^0.2.0",
-            "safe-stable-stringify": "^2.3.1",
-            "sonic-boom": "^4.0.1",
-            "thread-stream": "^3.0.0"
-          }
-        },
-        "pino-abstract-transport": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-          "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-          "requires": {
-            "split2": "^4.0.0"
-          }
-        },
-        "pino-std-serializers": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-          "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-        },
-        "process-warning": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
-          "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="
-        },
-        "sonic-boom": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-          "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-          "requires": {
-            "atomic-sleep": "^1.0.0"
-          }
-        },
-        "thread-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-          "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-          "requires": {
-            "real-require": "^0.2.0"
-          }
         }
       }
     },
     "@dotcom-reliability-kit/logger": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.10.tgz",
-      "integrity": "sha512-em76yWZqoA6lXMLYci6HP531KkAN0W2jjlUWp6hP3TnN1FBSFMIJmiJGHDQ1dFo7TtzcjdBLN0YU7ELHi8qmAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.1.0.tgz",
+      "integrity": "sha512-on88GAaV/shWS3otQ+M4wn5v/RZvRJxFoDz9IzV7STW5CTnfumH7ftdi5Qo0xVLQpbCTEy1heC1fKz6BwJRX6Q==",
       "requires": {
-        "@dotcom-reliability-kit/app-info": "^2.2.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
-        "pino": "^8.15.1"
+        "pino": "^9.6.0"
       },
       "dependencies": {
         "@dotcom-reliability-kit/app-info": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.2.0.tgz",
-          "integrity": "sha512-HG+BLc/YrZ/bitev5CDQiibbGvZEyyDy/U7GWvkAMu5HQhJVMB310MhwO0i3jYfYJGfXuaYZ8eypgbG9TzBdKA=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-4.1.0.tgz",
+          "integrity": "sha512-Ny5oQi+jOWcXNXjRdI37QeNcRZTjuBZGj3RXAT0tXKSUgKlnpPdkwV5L9lSiaK9EmWmuczIiHn11RCZ/M8Eegw=="
         },
         "@dotcom-reliability-kit/serialize-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
-          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
+          "integrity": "sha512-nMt/bYRzdFEtq9JM5S6nBL3+UaO+XQTf8mYTPa7Tl7x0A+A31XGnpCcIOite4NekbSaWEVagzJBAK5xaJCklYQ=="
         }
       }
     },
@@ -24053,6 +23696,65 @@
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "http-errors": "^1.8.0",
         "signed-aws-es-fetch": "^1.6.0"
+      },
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.3.0.tgz",
+          "integrity": "sha512-LMyL1tmNOl5aRtBih4EewqXEUK8oOF7j4sa8WCnDUdVlJedUl09iZrBk5th20qvgk2DzO0b5XwKVPLsVWvutCg=="
+        },
+        "@dotcom-reliability-kit/logger": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.4.2.tgz",
+          "integrity": "sha512-Gv5mist7h61Ostagp08KnyyCn25FgzSKRdpIPRTbd412pci8i3rHLwADHUROfDjvNX/bVRBd0sda9RCbkF6aIA==",
+          "requires": {
+            "@dotcom-reliability-kit/app-info": "^2.3.0",
+            "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+            "lodash.clonedeep": "^4.5.0",
+            "pino": "^8.17.1"
+          }
+        },
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.2.1.tgz",
+          "integrity": "sha512-JP8skyGR3YcCo2tTZogYoLUPWrs5Se+d07MZfBeCXMb2+2BmM79/3V8B6HJ8jPFq6/f6nVVFbQ7VpgHnNk6T2Q=="
+        },
+        "pino": {
+          "version": "8.21.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+          "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "fast-redact": "^3.1.1",
+            "on-exit-leak-free": "^2.1.0",
+            "pino-abstract-transport": "^1.2.0",
+            "pino-std-serializers": "^6.0.0",
+            "process-warning": "^3.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "real-require": "^0.2.0",
+            "safe-stable-stringify": "^2.3.1",
+            "sonic-boom": "^3.7.0",
+            "thread-stream": "^2.6.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+        },
+        "thread-stream": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+          "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "requires": {
+            "real-require": "^0.2.0"
+          }
+        }
       }
     },
     "@financial-times/n-express": {
@@ -24079,98 +23781,6 @@
             "lodash.clonedeep": "^4.5.0",
             "pino": "^9.4.0"
           }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "pino": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-          "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "fast-redact": "^3.1.1",
-            "on-exit-leak-free": "^2.1.0",
-            "pino-abstract-transport": "^1.2.0",
-            "pino-std-serializers": "^7.0.0",
-            "process-warning": "^4.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "real-require": "^0.2.0",
-            "safe-stable-stringify": "^2.3.1",
-            "sonic-boom": "^4.0.1",
-            "thread-stream": "^3.0.0"
-          }
-        },
-        "pino-abstract-transport": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-          "requires": {
-            "readable-stream": "^4.0.0",
-            "split2": "^4.0.0"
-          }
-        },
-        "pino-std-serializers": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-          "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-        },
-        "process-warning": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-          "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "sonic-boom": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-          "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-          "requires": {
-            "atomic-sleep": "^1.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "thread-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-          "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-          "requires": {
-            "real-require": "^0.2.0"
-          }
         }
       }
     },
@@ -24184,12 +23794,69 @@
         "vary": "^1.1.2"
       },
       "dependencies": {
+        "@dotcom-reliability-kit/app-info": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.3.0.tgz",
+          "integrity": "sha512-LMyL1tmNOl5aRtBih4EewqXEUK8oOF7j4sa8WCnDUdVlJedUl09iZrBk5th20qvgk2DzO0b5XwKVPLsVWvutCg=="
+        },
+        "@dotcom-reliability-kit/logger": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.4.2.tgz",
+          "integrity": "sha512-Gv5mist7h61Ostagp08KnyyCn25FgzSKRdpIPRTbd412pci8i3rHLwADHUROfDjvNX/bVRBd0sda9RCbkF6aIA==",
+          "requires": {
+            "@dotcom-reliability-kit/app-info": "^2.3.0",
+            "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+            "lodash.clonedeep": "^4.5.0",
+            "pino": "^8.17.1"
+          }
+        },
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.2.1.tgz",
+          "integrity": "sha512-JP8skyGR3YcCo2tTZogYoLUPWrs5Se+d07MZfBeCXMb2+2BmM79/3V8B6HJ8jPFq6/f6nVVFbQ7VpgHnNk6T2Q=="
+        },
         "n-eager-fetch": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.2.0.tgz",
           "integrity": "sha512-ilMmccSqxtOccfPJaAf+nlzn2xDhGBOYgki8l6WMuncK/SIsoAm2I1YVwaTYiKbmBMMx55BE/uVvLAxg1kn0wQ==",
           "requires": {
             "isomorphic-fetch": "^3.0.0"
+          }
+        },
+        "pino": {
+          "version": "8.21.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+          "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "fast-redact": "^3.1.1",
+            "on-exit-leak-free": "^2.1.0",
+            "pino-abstract-transport": "^1.2.0",
+            "pino-std-serializers": "^6.0.0",
+            "process-warning": "^3.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "real-require": "^0.2.0",
+            "safe-stable-stringify": "^2.3.1",
+            "sonic-boom": "^3.7.0",
+            "thread-stream": "^2.6.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+        },
+        "thread-stream": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+          "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "requires": {
+            "real-require": "^0.2.0"
           }
         }
       }
@@ -24222,14 +23889,6 @@
             "stack-trace": "0.0.x"
           }
         }
-      }
-    },
-    "@financial-times/n-mask-logger": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
-      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
-      "requires": {
-        "@financial-times/n-logger": "^10.2.0"
       }
     },
     "@financial-times/n-test": {
@@ -31529,98 +31188,6 @@
             "lodash.clonedeep": "^4.5.0",
             "pino": "^9.4.0"
           }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "pino": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-          "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "fast-redact": "^3.1.1",
-            "on-exit-leak-free": "^2.1.0",
-            "pino-abstract-transport": "^1.2.0",
-            "pino-std-serializers": "^7.0.0",
-            "process-warning": "^4.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "real-require": "^0.2.0",
-            "safe-stable-stringify": "^2.3.1",
-            "sonic-boom": "^4.0.1",
-            "thread-stream": "^3.0.0"
-          }
-        },
-        "pino-abstract-transport": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-          "requires": {
-            "readable-stream": "^4.0.0",
-            "split2": "^4.0.0"
-          }
-        },
-        "pino-std-serializers": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-          "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-        },
-        "process-warning": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-          "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "sonic-boom": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-          "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-          "requires": {
-            "atomic-sleep": "^1.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "thread-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-          "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-          "requires": {
-            "real-require": "^0.2.0"
-          }
         }
       }
     },
@@ -31719,98 +31286,6 @@
             "@dotcom-reliability-kit/serialize-error": "^3.2.0",
             "lodash.clonedeep": "^4.5.0",
             "pino": "^9.4.0"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "pino": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-          "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "fast-redact": "^3.1.1",
-            "on-exit-leak-free": "^2.1.0",
-            "pino-abstract-transport": "^1.2.0",
-            "pino-std-serializers": "^7.0.0",
-            "process-warning": "^4.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "real-require": "^0.2.0",
-            "safe-stable-stringify": "^2.3.1",
-            "sonic-boom": "^4.0.1",
-            "thread-stream": "^3.0.0"
-          }
-        },
-        "pino-abstract-transport": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-          "requires": {
-            "readable-stream": "^4.0.0",
-            "split2": "^4.0.0"
-          }
-        },
-        "pino-std-serializers": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-          "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
-        },
-        "process-warning": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-          "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "sonic-boom": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-          "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
-          "requires": {
-            "atomic-sleep": "^1.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "thread-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-          "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-          "requires": {
-            "real-require": "^0.2.0"
           }
         }
       }
@@ -35752,27 +35227,45 @@
       }
     },
     "pino": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.1.tgz",
-      "integrity": "sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
+      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.1.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.0.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "pino-abstract-transport": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+          "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+          "requires": {
+            "split2": "^4.0.0"
+          }
+        },
+        "sonic-boom": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+          "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        }
       }
     },
     "pino-abstract-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
-      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
       "requires": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -35894,9 +35387,9 @@
       }
     },
     "pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
     },
     "pkg-dir": {
       "version": "5.0.0",
@@ -36412,9 +35905,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "process-warning": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.0.tgz",
-      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="
     },
     "progress": {
       "version": "2.0.3",
@@ -38055,9 +37548,9 @@
       "dev": true
     },
     "thread-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
-      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "requires": {
         "real-require": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "dependencies": {
     "@dotcom-reliability-kit/crash-handler": "^5.0.0",
+    "@dotcom-reliability-kit/logger": "^4.1.0",
     "@dotcom-reliability-kit/middleware-log-errors": "^5.0.0",
     "@financial-times/n-es-client": "^6.0.1",
     "@financial-times/n-express": "^31.9.4",
-    "@financial-times/n-mask-logger": "7.2.0",
     "ajv": "^6.0.0",
     "archiver": "^6.0.0",
     "aws-sdk": "^2.85.0",

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,17 +1,22 @@
-const MaskLogger = require('@financial-times/n-mask-logger');
+const { Logger: ReliabilityKitLogger, transforms } = require('@dotcom-reliability-kit/logger');
 const  { metrics } = require('@financial-times/n-express');
 
-
-const _logger = new MaskLogger([
-	'email',
-	'password',
-	'contract_id',
-	'first_name',
-	'surname',
-	'uri',
-	'user_name',
-	'x-api-key'
-]);
+const _logger = new ReliabilityKitLogger({
+	transforms: [
+		transforms.legacyMask({
+			denyList: [
+				'email',
+				'password',
+				'contract_id',
+				'first_name',
+				'surname',
+				'uri',
+				'user_name',
+				'x-api-key'
+			],
+		}),
+	],
+});
 
 class Logger {
 


### PR DESCRIPTION
### Description

This migrates the system to use Reliability Kit logger instead of the deprecated n-mask-logger. There are a few things in the custom `Logger` class in this system that are handled by Reliability Kit logger (e.g. baseLogData), however, I wanted to keep this simple and just extract the old dependency.

At some point in future you may want to refactor/reassess the need for such a comprehensive helper.